### PR TITLE
1.4.1

### DIFF
--- a/class-integrate-convertkit-wpforms.php
+++ b/class-integrate-convertkit-wpforms.php
@@ -145,7 +145,7 @@ class Integrate_ConvertKit_WPForms {
 		$args['email'] = $fields[ $email_field_id ]['value'];
 
 		$first_name_field_id = $form_data['settings']['be_convertkit_field_first_name'];
-		if ( ! empty( $first_name_field_id ) && ! empty( $fields[ $first_name_field_id ]['value'] ) ) {
+		if ( $first_name_field_id !== '' && ! empty( $fields[ $first_name_field_id ]['value'] ) ) {
 			$args['first_name'] = $fields[ $first_name_field_id ]['value'];
 		}
 

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,9 @@
     "description": "ConvertKit for WPForms Plugin",
     "type": "project",
     "license": "GPLv3",
+    "require": {
+        "convertkit/convertkit-wordpress-libraries": "1.2.1"
+    },
     "require-dev": {
         "lucatume/wp-browser": "^3.0",
         "codeception/module-asserts": "^1.3",                                      
@@ -53,5 +56,11 @@
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
         }
-    }
+    },
+    "repositories": [
+        {
+            "url": "https://github.com/convertkit/convertkit-wordpress-libraries.git",
+            "type": "git"
+        }
+    ]
 }

--- a/includes/class-integrate-convertkit-wpforms-api.php
+++ b/includes/class-integrate-convertkit-wpforms-api.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * ConvertKit API class for WPForms.
+ *
+ * @package ConvertKit_WPForms
+ * @author ConvertKit
+ */
+
+/**
+ * ConvertKit API class for WPForms.
+ *
+ * @package ConvertKit_WPForms
+ * @author ConvertKit
+ */
+class Integrate_ConvertKit_WPForms_API extends ConvertKit_API {
+
+	/**
+	 * Holds the log class for writing to the log file
+	 *
+	 * @var bool
+	 */
+	public $log = false; // @phpstan-ignore-line
+
+	/**
+	 * Holds an array of error messages, localized to the plugin
+	 * using this API class.
+	 *
+	 * @var bool|array
+	 */
+	public $error_messages = false;
+
+	/**
+	 * Sets up the API with the required credentials.
+	 *
+	 * @since   1.4.1
+	 *
+	 * @param   bool|string $api_key        ConvertKit API Key.
+	 * @param   bool|string $api_secret     ConvertKit API Secret.
+	 * @param   bool|object $debug          Save data to log.
+	 */
+	public function __construct( $api_key = false, $api_secret = false, $debug = false ) {
+
+		// Set API credentials, debugging and logging class.
+		$this->api_key        = $api_key;
+		$this->api_secret     = $api_secret;
+		$this->debug          = $debug;
+		$this->plugin_name    = ( defined( 'CKWC_PLUGIN_NAME' ) ? CKWC_PLUGIN_NAME : false );
+		$this->plugin_path    = ( defined( 'CKWC_PLUGIN_PATH' ) ? CKWC_PLUGIN_PATH : false );
+		$this->plugin_url     = ( defined( 'CKWC_PLUGIN_URL' ) ? CKWC_PLUGIN_URL : false );
+		$this->plugin_version = ( defined( 'CKWC_PLUGIN_VERSION' ) ? CKWC_PLUGIN_VERSION : false );
+
+		// Setup logging class if the required parameters exist.
+		if ( $this->debug && $this->plugin_path !== false ) {
+			$this->log = new WC_Logger();
+		}
+
+		// Define translatable / localized error strings.
+		// WordPress requires that the text domain be a string (e.g. 'integrate-convertkit-wpforms') and not a variable,
+		// otherwise localization won't work.
+		$this->error_messages = array(
+			'form_subscribe_form_id_empty'                => __( 'form_subscribe(): the form_id parameter is empty.', 'integrate-convertkit-wpforms' ),
+			'form_subscribe_email_empty'                  => __( 'form_subscribe(): the email parameter is empty.', 'integrate-convertkit-wpforms' ),
+
+			'sequence_subscribe_sequence_id_empty'        => __( 'sequence_subscribe(): the sequence_id parameter is empty.', 'integrate-convertkit-wpforms' ),
+			'sequence_subscribe_email_empty'              => __( 'sequence_subscribe(): the email parameter is empty.', 'integrate-convertkit-wpforms' ),
+
+			'tag_subscribe_tag_id_empty'                  => __( 'tag_subscribe(): the tag_id parameter is empty.', 'integrate-convertkit-wpforms' ),
+			'tag_subscribe_email_empty'                   => __( 'tag_subscribe(): the email parameter is empty.', 'integrate-convertkit-wpforms' ),
+
+			'get_subscriber_by_email_email_empty'         => __( 'get_subscriber_by_email(): the email parameter is empty.', 'integrate-convertkit-wpforms' ),
+			/* translators: Email Address */
+			'get_subscriber_by_email_none'                => __( 'No subscriber(s) exist in ConvertKit matching the email address %s.', 'integrate-convertkit-wpforms' ),
+
+			'get_subscriber_by_id_subscriber_id_empty'    => __( 'get_subscriber_by_id(): the subscriber_id parameter is empty.', 'integrate-convertkit-wpforms' ),
+
+			'get_subscriber_tags_subscriber_id_empty'     => __( 'get_subscriber_tags(): the subscriber_id parameter is empty.', 'integrate-convertkit-wpforms' ),
+
+			'unsubscribe_email_empty'                     => __( 'unsubscribe(): the email parameter is empty.', 'integrate-convertkit-wpforms' ),
+
+			'get_all_posts_posts_per_request_bound_too_low' => __( 'get_all_posts(): the posts_per_request parameter must be equal to or greater than 1.', 'integrate-convertkit-wpforms' ),
+			'get_all_posts_posts_per_request_bound_too_high' => __( 'get_all_posts(): the posts_per_request parameter must be equal to or less than 50.', 'integrate-convertkit-wpforms' ),
+
+			'get_posts_page_parameter_bound_too_low'      => __( 'get_posts(): the page parameter must be equal to or greater than 1.', 'integrate-convertkit-wpforms' ),
+			'get_posts_per_page_parameter_bound_too_low'  => __( 'get_posts(): the per_page parameter must be equal to or greater than 1.', 'integrate-convertkit-wpforms' ),
+			'get_posts_per_page_parameter_bound_too_high' => __( 'get_posts(): the per_page parameter must be equal to or less than 50.', 'integrate-convertkit-wpforms' ),
+
+			/* translators: HTTP method */
+			'request_method_unsupported'                  => __( 'API request method %s is not supported in ConvertKit_API class.', 'integrate-convertkit-wpforms' ),
+			'request_rate_limit_exceeded'                 => __( 'Rate limit hit.', 'integrate-convertkit-wpforms' ),
+			'response_type_unexpected'                    => __( 'The response from the API is not of the expected type array.', 'integrate-convertkit-wpforms' ),
+		);
+
+	}
+
+}

--- a/integrate-convertkit-wpforms.php
+++ b/integrate-convertkit-wpforms.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * Plugin Name: Integrate ConvertKit and WPForms
- * Plugin URI:  https://www.billerickson.net/how-to-setup-convertkit-with-a-wordpress-form
+ * Plugin URI:  https://convertkit.com
  * Description: Create ConvertKit signup forms using WPForms
- * Version:     1.4.0
- * Author:      Bill Erickson
- * Author URI:  https://www.billerickson.net
+ * Version:     1.4.1
+ * Author:      ConvertKit
+ * Author URI:  https://convertkit.com
  * Text Domain: integrate-convertkit-wpforms
  * Domain Path: /languages
  * License:     GPLv2 or later

--- a/integrate-convertkit-wpforms.php
+++ b/integrate-convertkit-wpforms.php
@@ -31,8 +31,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-// Plugin version.
+// Define ConverKit Plugin paths and version number.
+define( 'INTEGRATE_CONVERTKIT_WPFORMS_NAME', 'ConvertKitWPForms' ); // Used for user-agent in API class.
+define( 'INTEGRATE_CONVERTKIT_WPFORMS_FILE', plugin_basename( __FILE__ ) );
+define( 'INTEGRATE_CONVERTKIT_WPFORMS_URL', plugin_dir_url( __FILE__ ) );
+define( 'INTEGRATE_CONVERTKIT_WPFORMS_PATH', __DIR__ );
 define( 'INTEGRATE_CONVERTKIT_WPFORMS_VERSION', '1.4.0' );
+
+// Load shared classes, if they have not been included by another ConvertKit Plugin.
+if ( ! class_exists( 'ConvertKit_API' ) ) {
+	require_once INTEGRATE_CONVERTKIT_WPFORMS_PATH . '/vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-api.php';
+}
 
 /**
  * Load the class
@@ -41,7 +50,8 @@ function integrate_convertkit_wpforms() {
 
 	load_plugin_textdomain( 'integrate-convertkit-wpforms', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
 
-	require_once plugin_dir_path( __FILE__ ) . 'class-integrate-convertkit-wpforms.php';
+	require_once plugin_dir_path( __FILE__ ) . '/includes/class-integrate-convertkit-wpforms-api.php';
+	require_once plugin_dir_path( __FILE__ ) . '/includes/class-integrate-convertkit-wpforms.php';
 
 }
 add_action( 'wpforms_loaded', 'integrate_convertkit_wpforms' );

--- a/readme.txt
+++ b/readme.txt
@@ -39,6 +39,9 @@ I recommend that you only enable logging for as long as necessary to debug your 
 
 == Changelog ==
 
+= 1.4.1 =
+* Fix: Include name when subscribing to ConvertKit, when the Name field is mapped to the first WPForms Form Field
+
 = 1.4.0 =
 - Added support for WPForms Log (Tools > Logs > select provider)
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === Integrate ConvertKit and WPForms ===
-Contributors: billerickson
-Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=ZHXHYVWJCTZ94
+Contributors: nathanbarry, convertkit, billerickson
+Donate link: https://convertkit.com
 Tags: form, wpforms, convertkit, email, marketing
-Requires at least: 3.0.1
-Tested up to: 5.7
-Stable tag: 1.4.0
+Requires at least: 5.0
+Tested up to: 6.1.1
+Stable tag: 1.4.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -12,7 +12,7 @@ Create ConvertKit signup forms using WPForms
 
 == Description ==
 
-"Integrate ConvertKit and WPForms" easily connects forms on your website to your [ConvertKit](http://mbsy.co/convertkit/28981746) email marketing account, enabling you to capture more leads and manage campaigns more effectively.
+"Integrate ConvertKit and WPForms" easily connects forms on your website to your [ConvertKit](https://convertkit.com) email marketing account, enabling you to capture more leads and manage campaigns more effectively.
 
 [WPForms](http://www.shareasale.com/r.cfm?u=402581&b=834775&m=64312&afftrack=convertkit%2Dplugin&urllink=)' simple drag-and-drop form builder allows you to create new forms with ease and its clean, modern code makes customizations a snap. This integration also works with the free version, [WPForms Lite](https://wordpress.org/plugins/wpforms-lite/), but I highly recommend purchasing the full WPForms for the valuable premium features and support.
 

--- a/readme.txt
+++ b/readme.txt
@@ -40,7 +40,8 @@ I recommend that you only enable logging for as long as necessary to debug your 
 == Changelog ==
 
 = 1.4.1 =
-* Fix: Include name when subscribing to ConvertKit, when the Name field is mapped to the first WPForms Form Field
+* Fix: Include name when subscribing to ConvertKit, when the Name field is mapped to the first WPForms Form Field with an ID of zero
+* Fix: Include tags when subscribing to ConvertKit
 
 = 1.4.0 =
 - Added support for WPForms Log (Tools > Logs > select provider)


### PR DESCRIPTION
## Summary

- Added: Implements ConvertKit API class, as used on other ConvertKit Plugins
- Fix: Include name when subscribing to ConvertKit, when the Name field is mapped to the first WPForms Form Field with an ID of zero ([identified here](https://github.com/ConvertKit/convertkit-wpforms/pull/1))
- Fix: Include tags when subscribing to ConvertKit ([identified here](https://github.com/ConvertKit/convertkit-wpforms/pull/1))

## Testing

Existing tests now pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)