### PR TITLE
Add Tests for Integration

### DIFF
--- a/includes/class-integrate-convertkit-wpforms-setup.php
+++ b/includes/class-integrate-convertkit-wpforms-setup.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * Plugin activation, update and deactivation class.
+ *
+ * @package Integrate_ConvertKit_WPForms
+ * @author  ConvertKit
+ */
+
+/**
+ * Runs any steps required on plugin activation, update and deactivation.
+ *
+ * @package Integrate_ConvertKit_WPForms
+ * @author  ConvertKit
+ * @version 1.5.0
+ */
+class Integrate_ConvertKit_WPForms_Setup {
+
+	/**
+	 * Runs routines when the Plugin version has been updated.
+	 *
+	 * @since   1.5.0
+	 */
+	public function update() {
+
+		// Get installed Plugin version.
+		$current_version = get_option( 'integrate_convertkit_wpforms_version' );
+
+		// If the version number matches the plugin version, no update routines
+		// need to run.
+		if ( $current_version === INTEGRATE_CONVERTKIT_WPFORMS_VERSION ) {
+			return;
+		}
+
+		/**
+		 * 1.5.0: Migrate API settings from individual forms to integrations.
+		 */
+		if ( ! $current_version || version_compare( $current_version, '1.5.0', '<' ) ) {
+			$this->migrate_settings_from_forms_to_integrations();
+		}
+
+		// Update the installed version number in the options table.
+		update_option( 'integrate_convertkit_wpforms_version', INTEGRATE_CONVERTKIT_WPFORMS_VERSION );
+
+	}
+
+	/**
+	 * 1.5.0+: For each WPForms Form that has ConvertKit settings defined (API Key, Form ID etc), migrate
+	 * those settings to a provider connection (WPForms > ), and configures the WPForms Form to use the
+	 * integration connection instead of the form settings.
+	 *
+	 * @since   1.5.0
+	 */
+	private function migrate_settings_from_forms_to_integrations() {
+
+		// Bail if the WPForms handler class isn't available.
+		if ( ! class_exists( 'WPForms_Form_Handler' ) ) {
+			return;
+		}
+
+		// Get all forms.
+		$form_handler = new WPForms_Form_Handler();
+		$forms        = $form_handler->get();
+
+		// Bail if no WPForms Forms exist.
+		if ( ! is_array( $forms ) ) {
+			return;
+		}
+		if ( count( $forms ) === 0 ) {
+			return;
+		}
+
+		// For each form, inspect its settings to determine if < 1.5.0 ConvertKit settings exist in the Form.
+		foreach ( $forms as $form ) {
+			// Decode settings into array.
+			$data = wpforms_decode( $form->post_content );
+
+			// Skip if this Form already has a ConvertKit provider configured.
+			// This shouldn't be the case for upgrades to 1.5.0+, but it's a useful
+			// sanity check.
+			if ( array_key_exists( 'providers', $data ) && array_key_exists( 'convertkit', $data['providers'] ) ) {
+				continue;
+			}
+
+			// Bail if the API Key or Form ID settings don't exist or are empty.
+			if ( ! array_key_exists( 'be_convertkit_api', $data['settings'] ) ) {
+				continue;
+			}
+			if ( empty( $data['settings']['be_convertkit_api'] ) ) {
+				continue;
+			}
+			if ( ! array_key_exists( 'be_convertkit_form_id', $data['settings'] ) ) {
+				continue;
+			}
+			if ( empty( $data['settings']['be_convertkit_form_id'] ) ) {
+				continue;
+			}
+
+			// Search WPForms provider accounts to see if an account exists for this ConvertKit API Key.
+			$account_id = $this->wpforms_get_provider_account_by_api_key( $data['settings']['be_convertkit_api'] );
+
+			// If no account exists, register a new ConvertKit provider account using this API Key.
+			if ( ! $account_id ) {
+				$account_id = $this->wpforms_register_account( $data['settings']['be_convertkit_api'] );
+			}
+
+			// Define the ConvertKit provider settings in the form.
+			$data['providers']['convertkit'] = array(
+				'connection_' . uniqid() => array(
+					'connection_name' => 'ConvertKit',
+					'account_id'      => $account_id,
+					'list_id'         => $data['settings']['be_convertkit_form_id'],
+					'fields'          => array(
+						'email' => $data['settings']['be_convertkit_field_email'] . '.value.email',
+						'name'  => $data['settings']['be_convertkit_field_first_name'] . '.value.text',
+					),
+				),
+			);
+
+			// Remove deprecated ConvertKit form settings.
+			unset(
+				$data['settings']['be_convertkit_api'],
+				$data['settings']['be_convertkit_form_id'],
+				$data['settings']['be_convertkit_field_first_name'],
+				$data['settings']['be_convertkit_field_email']
+			);
+
+			// Save data back to the form.
+			$form_handler->update( $form->ID, $data );
+		}
+
+	}
+
+	/**
+	 * Returns the account ID for the ConvertKit provider registered in WPForms
+	 * for the given ConvertKit API Key.
+	 *
+	 * Returns false if no provider is registered with the given API Key.
+	 *
+	 * @since   1.5.0
+	 *
+	 * @param   string $api_key    ConvertKit API Key.
+	 * @return  bool|string         false | Account ID.
+	 */
+	private function wpforms_get_provider_account_by_api_key( $api_key ) {
+
+		// Get all ConvertKit connections that are registered.
+		$connections = wpforms_get_providers_options( 'convertkit' );
+
+		// If no existing connections exist, register one now and return its ID.
+		if ( ! $connections ) {
+			return false;
+		}
+
+		foreach ( $connections as $id => $connection ) {
+			// If the connection's API Key matches the one we want to register a connection for,
+			// we can use the existing connection.
+			if ( $connection['api_key'] === $api_key ) {
+				return $id;
+			}
+		}
+
+		// If here, we have no existing ConvertKit connection for this API Key.
+		return false;
+
+	}
+
+	/**
+	 * Returns a ConvertKit provider account in WPForms for the given ConvertKit API Key.
+	 *
+	 * @since   1.5.0
+	 *
+	 * @param   string $api_key    ConvertKit API Key.
+	 * @return  string              Account ID
+	 */
+	private function wpforms_register_account( $api_key ) {
+
+		// wpforms_update_providers_options() doesn't return the generated ID
+		// for a new provider account, so we mimic how they generate an ID
+		// and return it.
+		$id = uniqid();
+
+		wpforms_update_providers_options(
+			'convertkit',
+			array(
+				'api_key'    => $api_key,
+				'api_secret' => '',
+				'label'      => 'ConvertKit',
+				'date'       => strtotime( 'now' ),
+			),
+			$id
+		);
+
+		return $id;
+
+	}
+
+}

--- a/includes/class-integrate-convertkit-wpforms.php
+++ b/includes/class-integrate-convertkit-wpforms.php
@@ -55,9 +55,24 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 		$this->priority = 14;
 		$this->icon     = INTEGRATE_CONVERTKIT_WPFORMS_URL . 'resources/backend/images/convertkit-logomark-red.svg';
 
+		// Run update routine.
+		add_action( 'init', array( $this, 'update' ) );
+
 		if ( is_admin() ) {
 			add_filter( "wpforms_providers_provider_settings_formbuilder_display_content_default_screen_{$this->slug}", array( $this, 'builder_settings_default_content' ) );
 		}
+
+	}
+
+	/**
+	 * Runs update/upgrade routines between Plugin versions.
+	 *
+	 * @since   1.5.0
+	 */
+	public function update() {
+
+		$setup = new Integrate_ConvertKit_WPForms_Setup();
+		$setup->update();
 
 	}
 

--- a/integrate-convertkit-wpforms.php
+++ b/integrate-convertkit-wpforms.php
@@ -3,7 +3,7 @@
  * Plugin Name: Integrate ConvertKit and WPForms
  * Plugin URI:  https://convertkit.com
  * Description: Create ConvertKit signup forms using WPForms
- * Version:     1.4.1
+ * Version:     1.5.0
  * Author:      ConvertKit
  * Author URI:  https://convertkit.com
  * Text Domain: integrate-convertkit-wpforms
@@ -36,7 +36,7 @@ define( 'INTEGRATE_CONVERTKIT_WPFORMS_NAME', 'ConvertKitWPForms' ); // Used for 
 define( 'INTEGRATE_CONVERTKIT_WPFORMS_FILE', plugin_basename( __FILE__ ) );
 define( 'INTEGRATE_CONVERTKIT_WPFORMS_URL', plugin_dir_url( __FILE__ ) );
 define( 'INTEGRATE_CONVERTKIT_WPFORMS_PATH', __DIR__ );
-define( 'INTEGRATE_CONVERTKIT_WPFORMS_VERSION', '1.4.0' );
+define( 'INTEGRATE_CONVERTKIT_WPFORMS_VERSION', '1.5.0' );
 
 // Load shared classes, if they have not been included by another ConvertKit Plugin.
 if ( ! class_exists( 'ConvertKit_API' ) ) {
@@ -51,6 +51,7 @@ function integrate_convertkit_wpforms() {
 	load_plugin_textdomain( 'integrate-convertkit-wpforms', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
 
 	require_once plugin_dir_path( __FILE__ ) . '/includes/class-integrate-convertkit-wpforms-api.php';
+	require_once plugin_dir_path( __FILE__ ) . '/includes/class-integrate-convertkit-wpforms-setup.php';
 	require_once plugin_dir_path( __FILE__ ) . '/includes/class-integrate-convertkit-wpforms.php';
 
 }

--- a/tests/_support/Helper/Acceptance/WPForms.php
+++ b/tests/_support/Helper/Acceptance/WPForms.php
@@ -34,6 +34,131 @@ class WPForms extends \Codeception\Module
 	}
 
 	/**
+	 * Creates a WPForms Form with ConvertKit Settings, as if it were created
+	 * in 1.4.1 or older.
+	 *
+	 * @since   1.5.0
+	 *
+	 * @param   AcceptanceTester $I AcceptanceTester.
+	 * @return  int                 Form ID.
+	 */
+	public function createWPFormsFormForMigration($I)
+	{
+		// Create Form, as if it were created with this Plugin < 1.5.0.
+		return $I->havePostInDatabase(
+			[
+				'post_type'    => 'wpforms',
+				'post_status'  => 'publish',
+				'post_title'   => 'Migrate form',
+				'post_name'    => 'migrate-form',
+				'post_content' => json_encode( // phpcs:ignore WordPress.WP.AlternativeFunctions
+					array(
+						'fields'   => array(
+							array(
+								'id'                 => '0',
+								'type'               => 'name',
+								'label'              => 'Name',
+								'format'             => 'first-last',
+								'description'        => '',
+								'required'           => '1',
+								'size'               => 'medium',
+								'simple_placeholder' => '',
+								'simple_default'     => '',
+								'first_placeholder'  => '',
+								'first_default'      => '',
+								'middle_placeholder' => '',
+								'middle_default'     => '',
+								'last_placeholder'   => '',
+								'last_default'       => '',
+								'css'                => '',
+							),
+							array(
+								'id'                       => '1',
+								'type'                     => 'email',
+								'label'                    => 'Email',
+								'description'              => '',
+								'required'                 => '1',
+								'size'                     => 'medium',
+								'placeholder'              => '',
+								'confirmation_placeholder' => '',
+								'default_value'            => false,
+								'filter_type'              => '',
+								'allowlist'                => '',
+								'denylist'                 => '',
+								'css'                      => '',
+							),
+							array(
+								'id'            => '2',
+								'type'          => 'textarea',
+								'label'         => 'Comment or Message',
+								'description'   => '',
+								'size'          => 'medium',
+								'placeholder'   => '',
+								'limit_count'   => '1',
+								'limit_mode'    => 'characters',
+								'default_value' => '',
+								'css'           => '',
+							),
+							array(
+								'id'            => '3',
+								'type'          => 'text',
+								'label'         => 'Tag ID',
+								'description'   => '',
+								'size'          => 'medium',
+								'placeholder'   => '',
+								'limit_count'   => '1',
+								'limit_mode'    => 'characters',
+								'default_value' => '',
+								'input_mask'    => '',
+								'css'           => '',
+							),
+						),
+						'id'       => '2',
+						'field_id' => 4,
+						'settings' => array(
+							'be_convertkit_api'         => $_ENV['CONVERTKIT_API_KEY'],
+							'be_convertkit_form_id'     => $_ENV['CONVERTKIT_API_FORM_ID'],
+							'be_convertkit_field_first_name' => '0',
+							'be_convertkit_field_email' => '1',
+							'form_title'                => 'Simple Contact Form',
+							'form_desc'                 => '',
+							'submit_text'               => 'Submit',
+							'submit_text_processing'    => 'Sending...',
+							'form_class'                => '',
+							'submit_class'              => '',
+							'ajax_submit'               => '1',
+							'notification_enable'       => '1',
+							'notifications'             => array(
+								1 => array(
+									'email'          => '{admin_email}',
+									'subject'        => 'New Entry: Simple Contact Form',
+									'sender_name'    => 'convertkit',
+									'sender_address' => '{admin_email}',
+									'replyto'        => '{field_id="1"}',
+									'message'        => '{all_fields}',
+								),
+							),
+							'confirmations'             => array(
+								1 => array(
+									'type'           => 'message',
+									'message'        => '<p>Thanks for contacting us! We will be in touch with you shortly.</p>',
+									'message_scroll' => '1',
+									'redirect'       => '',
+								),
+							),
+							'antispam'                  => '1',
+							'form_tags'                 => array(),
+						),
+						'meta'     => array(
+							'template' => 'simple-contact-form-template',
+						),
+					)
+				),
+			]
+		);
+	}
+
+	/**
 	 * Creates a WPForms Form.
 	 *
 	 * @since   1.4.0

--- a/tests/_support/Helper/Acceptance/WPForms.php
+++ b/tests/_support/Helper/Acceptance/WPForms.php
@@ -162,6 +162,54 @@ class WPForms extends \Codeception\Module
 	}
 
 	/**
+	 * Configures ConvertKit Settings for the given WPForms Form.
+	 *
+	 * @since   1.4.0
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester.
+	 * @param   int              $wpFormID      WPForms Form ID.
+	 * @param   bool|string      $customField   Custom Field (if specified, adds a field whose value will be used as a ConvertKit Custom Field Value).
+	 * @param   bool|string      $tagField      Tag Field (if specified, adds a field whose value will be used as a ConvertKit Tag).
+	 */
+	public function configureWPFormsBackwardCompatClasses($I, $wpFormID, $customField = false, $tagField = false)
+	{
+		// Load WPForms Editor.
+		$I->amOnAdminPage('admin.php?page=wpforms-builder&view=fields&form_id=' . $wpFormID);
+
+		// Custom Field.
+		if ($customField) {
+			// Click field.
+			$I->click('.wpforms-field-textarea');
+
+			// Click Advanced tab.
+			$I->click('.wpforms-field-option-textarea .wpforms-field-option-group-advanced a.wpforms-field-option-group-toggle');
+
+			// Add CSS class to tell Plugin that the value of this field is a custom field.
+			$I->waitForElementVisible('.wpforms-field-option-textarea .active');
+			$I->fillField('.wpforms-field-option-textarea .wpforms-field-option-row-css input[type=text]', 'ck-custom-' . $customField);
+		}
+
+		// Tag Field.
+		if ($tagField) {
+			// Click field.
+			$I->click('.wpforms-field-text');
+
+			// Click Advanced tab.
+			$I->click('.wpforms-field-option-text .wpforms-field-option-group-advanced a.wpforms-field-option-group-toggle');
+
+			// Add CSS class to tell Plugin that the value of this field is a tag field.
+			$I->waitForElementVisible('.wpforms-field-option-text .active');
+			$I->fillField('.wpforms-field-option-text .wpforms-field-option-row-css input[type=text]', 'ck-tag');
+		}
+
+		// Click Save.
+		$I->click('#wpforms-save');
+
+		// Wait for save to complete.
+		$I->waitForElementVisible('#wpforms-save:not(:disabled)');
+	}
+
+	/**
 	 * Creates a WordPress Page with the WPForms shortcode as the content
 	 * to render the WPForms Form.
 	 *

--- a/tests/acceptance/forms/FormBackwardCompatCest.php
+++ b/tests/acceptance/forms/FormBackwardCompatCest.php
@@ -332,6 +332,11 @@ class FormBackwardCompatCest
 	public function _passed(AcceptanceTester $I)
 	{
 		$I->deactivateConvertKitPlugin($I);
-		$I->deactivateThirdPartyPlugin($I, 'wpforms-lite');
+
+		// We don't use deactivateThirdPartyPlugin(), as this checks for PHP warnings/errors.
+		// WPForms throws a 502 bad gateway on deactivation, which is outside of our control
+		// and would result in the test not completing.
+		$I->amOnPluginsPage();
+		$I->deactivatePlugin('wpforms-lite');
 	}
 }

--- a/tests/acceptance/forms/FormBackwardCompatCest.php
+++ b/tests/acceptance/forms/FormBackwardCompatCest.php
@@ -1,0 +1,337 @@
+<?php
+/**
+ * Tests that the Plugin works when configuring and using WPForms
+ * with tag and custom field CSS classes, to ensure backward
+ * compatibility is maintained with 1.4.* and older.
+ *
+ * @since   1.5.0
+ */
+class FormBackwardCompatCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   1.5.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+		$I->activateThirdPartyPlugin($I, 'wpforms-lite');
+	}
+
+	/**
+	 * Test that the Plugin works when:
+	 * - Registering a ConvertKit integration connection,
+	 * - Creating a WPForms Form,
+	 * - Adding a field with the `ck-tag` CSS class, whose value will be a valid ConvertKit Tag ID.
+	 * - Submitting the Form on the frontend web site
+	 *
+	 * @since   1.5.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testCreateFormWithTagClass(AcceptanceTester $I)
+	{
+		// Define connection with valid API credentials.
+		$I->setupWPFormsIntegration($I);
+
+		// Create Form.
+		$wpFormsID = $I->createWPFormsForm($I);
+
+		// Configure ConvertKit API on Form.
+		$I->configureConvertKitSettingsOnForm(
+			$I,
+			$wpFormsID,
+			$_ENV['CONVERTKIT_API_FORM_NAME'],
+			'Name (First)',
+			'Email'
+		);
+
+		// Add `ck-tag` CSS class on Tag Field.
+		$I->configureWPFormsBackwardCompatClasses(
+			$I,
+			$wpFormsID,
+			false,
+			true
+		);
+
+		// Create a Page with the WPForms shortcode as its content.
+		$pageID = $I->createPageWithWPFormsShortcode($I, $wpFormsID);
+
+		// Define Name and Email Address for this Test.
+		$firstName    = 'First';
+		$lastName     = 'Last';
+		$emailAddress = $I->generateEmailAddress();
+
+		// Logout as the WordPress Administrator.
+		$I->logOut();
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Complete Form Fields.
+		$I->fillField('input.wpforms-field-name-first', $firstName);
+		$I->fillField('input.wpforms-field-name-last', $lastName);
+		$I->fillField('.wpforms-field-email input[type=email]', $emailAddress);
+		$I->fillField('.ck-tag input[type=text]', $_ENV['CONVERTKIT_API_TAG_ID']);
+
+		// Submit Form.
+		$I->click('Submit');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm submission was successful.
+		$I->waitForElementVisible('.wpforms-confirmation-scroll');
+		$I->seeInSource('Thanks for contacting us! We will be in touch with you shortly.');
+
+		// Check API to confirm subscriber was sent.
+		$I->apiCheckSubscriberExists($I, $emailAddress);
+
+		// Check API to confirm subscriber has Tag set.
+		$I->apiCheckSubscriberHasTag($I, $emailAddress, $_ENV['CONVERTKIT_API_TAG_ID']);
+	}
+
+	/**
+	 * Test that the Plugin works when:
+	 * - Registering a ConvertKit integration connection,
+	 * - Creating a WPForms Form,
+	 * - Adding a field with the `ck-tag` CSS class, whose value will be an invalid ConvertKit Tag ID.
+	 * - Submitting the Form on the frontend web site
+	 *
+	 * @since   1.5.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testCreateFormWithInvalidTag(AcceptanceTester $I)
+	{
+		// Define connection with valid API credentials.
+		$I->setupWPFormsIntegration($I);
+
+		// Create Form.
+		$wpFormsID = $I->createWPFormsForm($I);
+
+		// Configure ConvertKit API on Form.
+		$I->configureConvertKitSettingsOnForm(
+			$I,
+			$wpFormsID,
+			$_ENV['CONVERTKIT_API_FORM_NAME'],
+			'Name (First)',
+			'Email'
+		);
+
+		// Add `ck-tag` CSS class on Tag Field.
+		$I->configureWPFormsBackwardCompatClasses(
+			$I,
+			$wpFormsID,
+			false,
+			true
+		);
+
+		// Create a Page with the WPForms shortcode as its content.
+		$pageID = $I->createPageWithWPFormsShortcode($I, $wpFormsID);
+
+		// Define Name and Email Address for this Test.
+		$firstName    = 'First';
+		$lastName     = 'Last';
+		$emailAddress = $I->generateEmailAddress();
+
+		// Logout as the WordPress Administrator.
+		$I->logOut();
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Complete Form Fields.
+		$I->fillField('input.wpforms-field-name-first', $firstName);
+		$I->fillField('input.wpforms-field-name-last', $lastName);
+		$I->fillField('.wpforms-field-email input[type=email]', $emailAddress);
+		$I->fillField('.ck-tag input[type=text]', '1111');
+
+		// Submit Form.
+		$I->click('Submit');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm submission was successful.
+		$I->waitForElementVisible('.wpforms-confirmation-scroll');
+		$I->seeInSource('Thanks for contacting us! We will be in touch with you shortly.');
+
+		// Check API to confirm subscriber was sent.
+		$I->apiCheckSubscriberExists($I, $emailAddress, $firstName);
+	}
+
+	/**
+	 * Test that the Plugin works when:
+	 * - Registering a ConvertKit integration connection,
+	 * - Creating a WPForms Form,
+	 * - Adding a field with the `ck-custom-notes` CSS class, whose value will be the Custom Field's value,
+	 * - Submitting the Form on the frontend web site
+	 *
+	 * @since   1.5.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testCreateFormWithCustomField(AcceptanceTester $I)
+	{
+		// Define connection with valid API credentials.
+		$I->setupWPFormsIntegration($I);
+
+		// Create Form.
+		$wpFormsID = $I->createWPFormsForm($I);
+
+		// Configure ConvertKit API on Form.
+		$I->configureConvertKitSettingsOnForm(
+			$I,
+			$wpFormsID,
+			$_ENV['CONVERTKIT_API_FORM_NAME'],
+			'Name (First)',
+			'Email'
+		);
+
+		// Add `ck-custom-{name}` CSS class on Field.
+		$I->configureWPFormsBackwardCompatClasses(
+			$I,
+			$wpFormsID,
+			$_ENV['CONVERTKIT_API_CUSTOM_FIELD_NAME']
+		);
+
+		// Create a Page with the WPForms shortcode as its content.
+		$pageID = $I->createPageWithWPFormsShortcode($I, $wpFormsID);
+
+		// Define Name and Email Address for this Test.
+		$firstName    = 'First';
+		$lastName     = 'Last';
+		$emailAddress = $I->generateEmailAddress();
+		$customFields = [
+			$_ENV['CONVERTKIT_API_CUSTOM_FIELD_NAME'] => 'Notes',
+		];
+
+		// Logout as the WordPress Administrator.
+		$I->logOut();
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Complete Form Fields.
+		$I->fillField('input.wpforms-field-name-first', $firstName);
+		$I->fillField('input.wpforms-field-name-last', $lastName);
+		$I->fillField('.wpforms-field-email input[type=email]', $emailAddress);
+		$I->fillField('.ck-custom-' . $_ENV['CONVERTKIT_API_CUSTOM_FIELD_NAME'] . ' textarea', $customFields[ $_ENV['CONVERTKIT_API_CUSTOM_FIELD_NAME'] ]);
+
+		// Submit Form.
+		$I->click('Submit');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm submission was successful.
+		$I->waitForElementVisible('.wpforms-confirmation-scroll');
+		$I->seeInSource('Thanks for contacting us! We will be in touch with you shortly.');
+
+		// Check API to confirm subscriber was sent and data mapped to fields correctly.
+		$I->apiCheckSubscriberExists($I, $emailAddress, $firstName, $customFields);
+	}
+
+	/**
+	 * Test that the Plugin works when:
+	 * - Creating a WPForms Form,
+	 * - Adding a valid API Key and valid Form ID,
+	 * - Adding a field whose value will be stored against a ConvertKit Custom Field.
+	 * - Submitting the Form on the frontend web site results works.
+	 *
+	 * @since   1.4.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testCreateFormWithInvalidCustomField(AcceptanceTester $I)
+	{
+		// Define connection with valid API credentials.
+		$I->setupWPFormsIntegration($I);
+
+		// Create Form.
+		$wpFormsID = $I->createWPFormsForm($I);
+
+		// Configure ConvertKit API on Form.
+		$I->configureConvertKitSettingsOnForm(
+			$I,
+			$wpFormsID,
+			$_ENV['CONVERTKIT_API_FORM_NAME'],
+			'Name (First)',
+			'Email'
+		);
+
+		// Add `ck-custom-{name}` CSS class on Field.
+		$I->configureWPFormsBackwardCompatClasses(
+			$I,
+			$wpFormsID,
+			'fakeCustomFieldName'
+		);
+
+		// Create a Page with the WPForms shortcode as its content.
+		$pageID = $I->createPageWithWPFormsShortcode($I, $wpFormsID);
+
+		// Define Name and Email Address for this Test.
+		$firstName    = 'First';
+		$lastName     = 'Last';
+		$emailAddress = $I->generateEmailAddress();
+		$customFields = [
+			'fakeCustomFieldName' => 'Notes',
+		];
+
+		// Logout as the WordPress Administrator.
+		$I->logOut();
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Complete Form Fields.
+		$I->fillField('input.wpforms-field-name-first', $firstName);
+		$I->fillField('input.wpforms-field-name-last', $lastName);
+		$I->fillField('.wpforms-field-email input[type=email]', $emailAddress);
+		$I->fillField('.ck-custom-fakeCustomFieldName textarea', $customFields['fakeCustomFieldName']);
+
+		// Submit Form.
+		$I->click('Submit');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm submission was successful.
+		$I->waitForElementVisible('.wpforms-confirmation-scroll');
+		$I->seeInSource('Thanks for contacting us! We will be in touch with you shortly.');
+
+		// Check API to confirm subscriber was sent.
+		$I->apiCheckSubscriberExists($I, $emailAddress, $firstName);
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   1.5.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->deactivateThirdPartyPlugin($I, 'wpforms-lite');
+	}
+}

--- a/tests/acceptance/forms/FormCest.php
+++ b/tests/acceptance/forms/FormCest.php
@@ -302,6 +302,11 @@ class FormCest
 	public function _passed(AcceptanceTester $I)
 	{
 		$I->deactivateConvertKitPlugin($I);
-		$I->deactivateThirdPartyPlugin($I, 'wpforms-lite');
+
+		// We don't use deactivateThirdPartyPlugin(), as this checks for PHP warnings/errors.
+		// WPForms throws a 502 bad gateway on deactivation, which is outside of our control
+		// and would result in the test not completing.
+		$I->amOnPluginsPage();
+		$I->deactivatePlugin('wpforms-lite');
 	}
 }

--- a/tests/acceptance/forms/FormCest.php
+++ b/tests/acceptance/forms/FormCest.php
@@ -247,7 +247,7 @@ class FormCest
 			'Email',
 			array(  // Custom Fields.
 				$_ENV['CONVERTKIT_API_CUSTOM_FIELD_NAME'] => 'Comment or Message', // ConvertKit Custom Field --> WPForms Field Name mapping.
-			),
+			)
 		);
 
 		// Create a Page with the WPForms shortcode as its content.

--- a/tests/acceptance/forms/FormCest.php
+++ b/tests/acceptance/forms/FormCest.php
@@ -2,14 +2,14 @@
 /**
  * Tests that the Plugin works when configuring and using WPForms.
  *
- * @since   1.4.0
+ * @since   1.5.0
  */
 class FormCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
 	 *
-	 * @since   1.4.0
+	 * @since   1.5.0
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
@@ -22,26 +22,27 @@ class FormCest
 	/**
 	 * Test that the Plugin works when:
 	 * - Creating a WPForms Form,
-	 * - Adding a valid API Key and Form ID,
-	 * - Submitting the Form on the frontend web site results in the email address subscribing to the ConvertKit Form,
-	 * and the first name being included.
+	 * - Adding a valid ConvertKit Connection,
+	 * - Submitting the Form on the frontend web site results in the email address subscribing to the ConvertKit Form.
 	 *
-	 * @since   1.4.0
+	 * @since   1.5.0
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testCreateForm(AcceptanceTester $I)
 	{
+		// Define connection with valid API credentials.
+		$I->setupWPFormsIntegration($I);
+
 		// Create Form.
 		$wpFormsID = $I->createWPFormsForm($I);
 
-		// Configure ConvertKit API on Form.
+		// Configure ConvertKit on Form.
 		$I->configureConvertKitSettingsOnForm(
 			$I,
 			$wpFormsID,
-			$_ENV['CONVERTKIT_API_KEY'],
-			$_ENV['CONVERTKIT_API_FORM_ID'],
-			'Name',
+			$_ENV['CONVERTKIT_API_FORM_NAME'],
+			'Name (First)',
 			'Email'
 		);
 
@@ -78,218 +79,37 @@ class FormCest
 		$I->seeInSource('Thanks for contacting us! We will be in touch with you shortly.');
 
 		// Check API to confirm subscriber was sent.
-		$I->apiCheckSubscriberExists($I, $emailAddress, $firstName . ' ' . $lastName);
+		$I->apiCheckSubscriberExists($I, $emailAddress, $firstName);
 	}
 
 	/**
 	 * Test that the Plugin works when:
 	 * - Creating a WPForms Form,
-	 * - Adding an invalid API Key and Form ID,
-	 * - Submitting the Form on the frontend web site results works.
-	 *
-	 * @since   1.4.0
-	 *
-	 * @param   AcceptanceTester $I  Tester.
-	 */
-	public function testCreateFormWithInvalidAPIKey(AcceptanceTester $I)
-	{
-		// Create Form.
-		$wpFormsID = $I->createWPFormsForm($I);
-
-		// Configure ConvertKit API on Form.
-		$I->configureConvertKitSettingsOnForm(
-			$I,
-			$wpFormsID,
-			'invalidApiKey',
-			$_ENV['CONVERTKIT_API_FORM_ID'],
-			'Name',
-			'Email'
-		);
-
-		// Create a Page with the WPForms shortcode as its content.
-		$pageID = $I->createPageWithWPFormsShortcode($I, $wpFormsID);
-
-		// Define Name and Email Address for this Test.
-		$firstName    = 'First';
-		$lastName     = 'Last';
-		$emailAddress = $I->generateEmailAddress();
-
-		// Logout as the WordPress Administrator.
-		$I->logOut();
-
-		// Load the Page on the frontend site.
-		$I->amOnPage('/?p=' . $pageID);
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Complete Form Fields.
-		$I->fillField('input.wpforms-field-name-first', $firstName);
-		$I->fillField('input.wpforms-field-name-last', $lastName);
-		$I->fillField('.wpforms-field-email input[type=email]', $emailAddress);
-
-		// Submit Form.
-		$I->click('Submit');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Confirm submission was successful.
-		$I->waitForElementVisible('.wpforms-confirmation-scroll');
-		$I->seeInSource('Thanks for contacting us! We will be in touch with you shortly.');
-
-		// Check API to confirm subscriber was not sent.
-		$I->apiCheckSubscriberDoesNotExist($I, $emailAddress);
-	}
-
-	/**
-	 * Test that the Plugin works when:
-	 * - Creating a WPForms Form,
-	 * - Adding a valid API Key and no Form ID,
-	 * - Submitting the Form on the frontend web site results works.
-	 *
-	 * @since   1.4.0
-	 *
-	 * @param   AcceptanceTester $I  Tester.
-	 */
-	public function testCreateFormWithNoFormID(AcceptanceTester $I)
-	{
-		// Create Form.
-		$wpFormsID = $I->createWPFormsForm($I);
-
-		// Configure ConvertKit API on Form.
-		$I->configureConvertKitSettingsOnForm(
-			$I,
-			$wpFormsID,
-			$_ENV['CONVERTKIT_API_KEY'],
-			'',
-			'Name',
-			'Email'
-		);
-
-		// Create a Page with the WPForms shortcode as its content.
-		$pageID = $I->createPageWithWPFormsShortcode($I, $wpFormsID);
-
-		// Define Name and Email Address for this Test.
-		$firstName    = 'First';
-		$lastName     = 'Last';
-		$emailAddress = $I->generateEmailAddress();
-
-		// Logout as the WordPress Administrator.
-		$I->logOut();
-
-		// Load the Page on the frontend site.
-		$I->amOnPage('/?p=' . $pageID);
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Complete Form Fields.
-		$I->fillField('input.wpforms-field-name-first', $firstName);
-		$I->fillField('input.wpforms-field-name-last', $lastName);
-		$I->fillField('.wpforms-field-email input[type=email]', $emailAddress);
-
-		// Submit Form.
-		$I->click('Submit');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Confirm submission was successful.
-		$I->waitForElementVisible('.wpforms-confirmation-scroll');
-		$I->seeInSource('Thanks for contacting us! We will be in touch with you shortly.');
-
-		// Check API to confirm subscriber was not sent.
-		$I->apiCheckSubscriberDoesNotExist($I, $emailAddress);
-	}
-
-	/**
-	 * Test that the Plugin works when:
-	 * - Creating a WPForms Form,
-	 * - Adding a valid API Key and invalid Form ID,
-	 * - Submitting the Form on the frontend web site results works.
-	 *
-	 * @since   1.4.0
-	 *
-	 * @param   AcceptanceTester $I  Tester.
-	 */
-	public function testCreateFormWithInvalidFormID(AcceptanceTester $I)
-	{
-		// Create Form.
-		$wpFormsID = $I->createWPFormsForm($I);
-
-		// Configure ConvertKit API on Form.
-		$I->configureConvertKitSettingsOnForm(
-			$I,
-			$wpFormsID,
-			$_ENV['CONVERTKIT_API_KEY'],
-			'11111',
-			'Name',
-			'Email'
-		);
-
-		// Create a Page with the WPForms shortcode as its content.
-		$pageID = $I->createPageWithWPFormsShortcode($I, $wpFormsID);
-
-		// Define Name and Email Address for this Test.
-		$firstName    = 'First';
-		$lastName     = 'Last';
-		$emailAddress = $I->generateEmailAddress();
-
-		// Logout as the WordPress Administrator.
-		$I->logOut();
-
-		// Load the Page on the frontend site.
-		$I->amOnPage('/?p=' . $pageID);
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Complete Form Fields.
-		$I->fillField('input.wpforms-field-name-first', $firstName);
-		$I->fillField('input.wpforms-field-name-last', $lastName);
-		$I->fillField('.wpforms-field-email input[type=email]', $emailAddress);
-
-		// Submit Form.
-		$I->click('Submit');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Confirm submission was successful.
-		$I->waitForElementVisible('.wpforms-confirmation-scroll');
-		$I->seeInSource('Thanks for contacting us! We will be in touch with you shortly.');
-
-		// Check API to confirm subscriber was not sent.
-		$I->apiCheckSubscriberDoesNotExist($I, $emailAddress);
-	}
-
-	/**
-	 * Test that the Plugin works when:
-	 * - Creating a WPForms Form,
-	 * - Adding a valid API Key and valid Form ID,
+	 * - Adding a valid ConvertKit Connection,
 	 * - Adding a field whose value will be a valid ConvertKit Tag ID.
 	 * - Submitting the Form on the frontend web site results works.
 	 *
-	 * @since   1.4.0
+	 * @since   1.5.0
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testCreateFormWithTag(AcceptanceTester $I)
 	{
+		// Define connection with valid API credentials.
+		$I->setupWPFormsIntegration($I);
+
 		// Create Form.
 		$wpFormsID = $I->createWPFormsForm($I);
 
-		// Configure ConvertKit API on Form.
+		// Configure ConvertKit on Form.
 		$I->configureConvertKitSettingsOnForm(
 			$I,
 			$wpFormsID,
-			$_ENV['CONVERTKIT_API_KEY'],
-			$_ENV['CONVERTKIT_API_FORM_ID'],
-			'Name',
+			$_ENV['CONVERTKIT_API_FORM_NAME'],
+			'Name (First)',
 			'Email',
-			false,
-			true
+			false, // Custom Fields.
+			'Tag ID' // Name of Tag Field in WPForms.
 		);
 
 		// Create a Page with the WPForms shortcode as its content.
@@ -313,7 +133,7 @@ class FormCest
 		$I->fillField('input.wpforms-field-name-first', $firstName);
 		$I->fillField('input.wpforms-field-name-last', $lastName);
 		$I->fillField('.wpforms-field-email input[type=email]', $emailAddress);
-		$I->fillField('.ck-tag input[type=text]', $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->fillField('.wpforms-field-text input[type=text]', $_ENV['CONVERTKIT_API_TAG_ID']);
 
 		// Submit Form.
 		$I->click('Submit');
@@ -326,7 +146,7 @@ class FormCest
 		$I->seeInSource('Thanks for contacting us! We will be in touch with you shortly.');
 
 		// Check API to confirm subscriber was sent.
-		$I->apiCheckSubscriberExists($I, $emailAddress);
+		$I->apiCheckSubscriberExists($I, $emailAddress, $firstName);
 
 		// Check API to confirm subscriber has Tag set.
 		$I->apiCheckSubscriberHasTag($I, $emailAddress, $_ENV['CONVERTKIT_API_TAG_ID']);
@@ -339,25 +159,27 @@ class FormCest
 	 * - Adding a field whose value will be an invalid ConvertKit Tag ID.
 	 * - Submitting the Form on the frontend web site results works.
 	 *
-	 * @since   1.4.0
+	 * @since   1.5.0
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testCreateFormWithInvalidTag(AcceptanceTester $I)
 	{
+		// Define connection with valid API credentials.
+		$I->setupWPFormsIntegration($I);
+
 		// Create Form.
 		$wpFormsID = $I->createWPFormsForm($I);
 
-		// Configure ConvertKit API on Form.
+		// Configure ConvertKit on Form.
 		$I->configureConvertKitSettingsOnForm(
 			$I,
 			$wpFormsID,
-			$_ENV['CONVERTKIT_API_KEY'],
-			$_ENV['CONVERTKIT_API_FORM_ID'],
-			'Name',
+			$_ENV['CONVERTKIT_API_FORM_NAME'],
+			'Name (First)',
 			'Email',
-			false,
-			true
+			false, // Custom Fields.
+			'Tag ID' // Name of Tag Field in WPForms.
 		);
 
 		// Create a Page with the WPForms shortcode as its content.
@@ -381,7 +203,7 @@ class FormCest
 		$I->fillField('input.wpforms-field-name-first', $firstName);
 		$I->fillField('input.wpforms-field-name-last', $lastName);
 		$I->fillField('.wpforms-field-email input[type=email]', $emailAddress);
-		$I->fillField('', '1111');
+		$I->fillField('.wpforms-field-text input[type=text]', '1111');
 
 		// Submit Form.
 		$I->click('Submit');
@@ -394,10 +216,7 @@ class FormCest
 		$I->seeInSource('Thanks for contacting us! We will be in touch with you shortly.');
 
 		// Check API to confirm subscriber was sent.
-		$I->apiCheckSubscriberExists($I, $emailAddress);
-
-		// Check API to confirm subscriber does not have Tag, as an invalid tag ID was specified in the Form.
-		$I->apiCheckSubscriberDoesNotHaveTag($I, $emailAddress, $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberExists($I, $emailAddress, $firstName);
 	}
 
 	/**
@@ -407,25 +226,28 @@ class FormCest
 	 * - Adding a field whose value will be stored against a ConvertKit Custom Field.
 	 * - Submitting the Form on the frontend web site results works.
 	 *
-	 * @since   1.4.0
+	 * @since   1.5.0
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function testCreateFormWithCustomField(AcceptanceTester $I)
 	{
+		// Define connection with valid API credentials.
+		$I->setupWPFormsIntegration($I);
+
 		// Create Form.
 		$wpFormsID = $I->createWPFormsForm($I);
 
-		// Configure ConvertKit API on Form.
+		// Configure ConvertKit on Form.
 		$I->configureConvertKitSettingsOnForm(
 			$I,
 			$wpFormsID,
-			$_ENV['CONVERTKIT_API_KEY'],
-			$_ENV['CONVERTKIT_API_FORM_ID'],
-			'Name',
+			$_ENV['CONVERTKIT_API_FORM_NAME'],
+			'Name (First)',
 			'Email',
-			$_ENV['CONVERTKIT_API_CUSTOM_FIELD_NAME'],
-			false
+			array(  // Custom Fields.
+				$_ENV['CONVERTKIT_API_CUSTOM_FIELD_NAME'] => 'Comment or Message', // ConvertKit Custom Field --> WPForms Field Name mapping.
+			),
 		);
 
 		// Create a Page with the WPForms shortcode as its content.
@@ -452,7 +274,7 @@ class FormCest
 		$I->fillField('input.wpforms-field-name-first', $firstName);
 		$I->fillField('input.wpforms-field-name-last', $lastName);
 		$I->fillField('.wpforms-field-email input[type=email]', $emailAddress);
-		$I->fillField('.ck-custom-' . $_ENV['CONVERTKIT_API_CUSTOM_FIELD_NAME'] . ' input[type=text]', $customFields[ $_ENV['CONVERTKIT_API_CUSTOM_FIELD_NAME'] ]);
+		$I->fillField('.wpforms-field-textarea textarea', $customFields[ $_ENV['CONVERTKIT_API_CUSTOM_FIELD_NAME'] ]);
 
 		// Submit Form.
 		$I->click('Submit');
@@ -465,75 +287,7 @@ class FormCest
 		$I->seeInSource('Thanks for contacting us! We will be in touch with you shortly.');
 
 		// Check API to confirm subscriber was sent and data mapped to fields correctly.
-		$I->apiCheckSubscriberExists($I, $emailAddress, false, $customFields);
-	}
-
-	/**
-	 * Test that the Plugin works when:
-	 * - Creating a WPForms Form,
-	 * - Adding a valid API Key and valid Form ID,
-	 * - Adding a field whose value will be stored against a ConvertKit Custom Field.
-	 * - Submitting the Form on the frontend web site results works.
-	 *
-	 * @since   1.4.0
-	 *
-	 * @param   AcceptanceTester $I  Tester.
-	 */
-	public function testCreateFormWithInvalidCustomField(AcceptanceTester $I)
-	{
-		// Create Form.
-		$wpFormsID = $I->createWPFormsForm($I);
-
-		// Configure ConvertKit API on Form.
-		$I->configureConvertKitSettingsOnForm(
-			$I,
-			$wpFormsID,
-			$_ENV['CONVERTKIT_API_KEY'],
-			$_ENV['CONVERTKIT_API_FORM_ID'],
-			'Name',
-			'Email',
-			'fakeCustomFieldName',
-			false
-		);
-
-		// Create a Page with the WPForms shortcode as its content.
-		$pageID = $I->createPageWithWPFormsShortcode($I, $wpFormsID);
-
-		// Define Name and Email Address for this Test.
-		$firstName    = 'First';
-		$lastName     = 'Last';
-		$emailAddress = $I->generateEmailAddress();
-		$customFields = [
-			'fakeCustomFieldName' => 'Notes',
-		];
-
-		// Logout as the WordPress Administrator.
-		$I->logOut();
-
-		// Load the Page on the frontend site.
-		$I->amOnPage('/?p=' . $pageID);
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Complete Form Fields.
-		$I->fillField('input.wpforms-field-name-first', $firstName);
-		$I->fillField('input.wpforms-field-name-last', $lastName);
-		$I->fillField('.wpforms-field-email input[type=email]', $emailAddress);
-		$I->fillField('.ck-custom-fakeCustomFieldName input[type=text]', $customFields['fakeCustomFieldName']);
-
-		// Submit Form.
-		$I->click('Submit');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Confirm submission was successful.
-		$I->waitForElementVisible('.wpforms-confirmation-scroll');
-		$I->seeInSource('Thanks for contacting us! We will be in touch with you shortly.');
-
-		// Check API to confirm subscriber was sent, despite Custom Field data being invalid.
-		$I->apiCheckSubscriberExists($I, $emailAddress);
+		$I->apiCheckSubscriberExists($I, $emailAddress, $firstName, $customFields);
 	}
 
 	/**
@@ -541,18 +295,13 @@ class FormCest
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
 	 *
-	 * @since   1.4.0
+	 * @since   1.5.0
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
 	public function _passed(AcceptanceTester $I)
 	{
 		$I->deactivateConvertKitPlugin($I);
-
-		// We don't use deactivateThirdPartyPlugin(), as this checks for PHP warnings/errors.
-		// WPForms throws a 502 bad gateway on deactivation, which is outside of our control
-		// and would result in the test not completing.
-		$I->amOnPluginsPage();
-		$I->deactivatePlugin('wpforms-lite');
+		$I->deactivateThirdPartyPlugin($I, 'wpforms-lite');
 	}
 }

--- a/tests/acceptance/general/ActivateDeactivatePluginCest.php
+++ b/tests/acceptance/general/ActivateDeactivatePluginCest.php
@@ -34,6 +34,5 @@ class ActivateDeactivatePluginCest
 	{
 		$I->activateConvertKitPlugin($I);
 		$I->deactivateConvertKitPlugin($I);
-
 	}
 }

--- a/tests/acceptance/general/IntegrationsCest.php
+++ b/tests/acceptance/general/IntegrationsCest.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Tests that the ConvertKit Integration options work at WPForms > Settings > Integrations
+ *
+ * @since   1.5.0
+ */
+class IntegrationsCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   1.5.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+		$I->activateThirdPartyPlugin($I, 'wpforms-lite');
+	}
+
+	/**
+	 * Test that adding a ConvertKit account to the ConvertKit integration sections
+	 * works with valid API credentials.
+	 *
+	 * @since   1.5.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddIntegrationWithValidAPICredentials(AcceptanceTester $I)
+	{
+		// Load WPForms > Settings > Integrations.
+		$I->amOnAdminPage('admin.php?page=wpforms-settings&view=integrations');
+
+		// Expand ConvertKit integration section.
+		$I->click('#wpforms-integration-convertkit');
+
+		// Click Add New Account button.
+		$I->click('#wpforms-integration-convertkit a[data-provider="convertkit"]');
+
+		// Fill fields.
+		$I->waitForElementVisible('.wpforms-settings-provider-accounts-connect input[name="api_key"]');
+		$I->fillField('api_key', $_ENV['CONVERTKIT_API_KEY']);
+		$I->fillField('api_secret', $_ENV['CONVERTKIT_API_SECRET']);
+
+		// Click Connect to ConvertKit button.
+		$I->click('Connect to ConvertKit');
+
+		// Confirm that the 'Connected' element is visible.
+		$I->waitForElementVisible('#wpforms-integration-convertkit .wpforms-settings-provider-info .connected-indicator');
+		$I->see('Connected on:');
+
+		// Confirm that the connection can be disconnected.
+		$I->click('Disconnect');
+
+		// Confirm that we want to disconnect.
+		$I->waitForElementVisible('.jconfirm-box');
+		$I->click('.jconfirm-box button.btn-confirm');
+
+		// Confirm no connection is listed.
+		$I->wait(1);
+		$I->dontSee('Connected on:');
+	}
+
+	/**
+	 * Test that adding a ConvertKit account to the ConvertKit integration sections
+	 * shows the expected error message when supplying invalid API credentials.
+	 *
+	 * @since   1.5.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddIntegrationWithInvalidAPICredentials(AcceptanceTester $I)
+	{
+		// Load WPForms > Settings > Integrations.
+		$I->amOnAdminPage('admin.php?page=wpforms-settings&view=integrations');
+
+		// Expand ConvertKit integration section.
+		$I->click('#wpforms-integration-convertkit');
+
+		// Click Add New Account button.
+		$I->click('#wpforms-integration-convertkit a[data-provider="convertkit"]');
+
+		// Fill fields.
+		$I->waitForElementVisible('.wpforms-settings-provider-accounts-connect input[name="api_key"]');
+		$I->fillField('api_key', 'invalidApiKey');
+		$I->fillField('api_secret', 'invalidApiSecret');
+
+		// Click Connect to ConvertKit button.
+		$I->click('Connect to ConvertKit');
+
+		// Confirm the expected error message displays.
+		$I->waitForElementVisible('.jconfirm-box');
+		$I->see('Could not authenticate with the provider');
+		$I->see('Authorization Failed: API Key not valid');
+	}
+
+	/**
+	 * Test that adding a ConvertKit account to the ConvertKit integration sections
+	 * shows the expected error message when supplying no API credentials.
+	 *
+	 * @since   1.5.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testAddIntegrationWithNoAPICredentials(AcceptanceTester $I)
+	{
+		// Load WPForms > Settings > Integrations.
+		$I->amOnAdminPage('admin.php?page=wpforms-settings&view=integrations');
+
+		// Expand ConvertKit integration section.
+		$I->click('#wpforms-integration-convertkit');
+
+		// Click Add New Account button.
+		$I->click('#wpforms-integration-convertkit a[data-provider="convertkit"]');
+
+		// Click Connect to ConvertKit button.
+		$I->waitForElementVisible('.wpforms-settings-provider-accounts-connect input[name="api_key"]');
+		$I->click('Connect to ConvertKit');
+
+		// Confirm the expected error message displays.
+		$I->waitForElementVisible('.jconfirm-box');
+		$I->see('Could not authenticate with the provider');
+		$I->see('The API Key is required');
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   1.5.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->deactivateThirdPartyPlugin($I, 'wpforms-lite');
+	}
+}

--- a/tests/acceptance/general/IntegrationsCest.php
+++ b/tests/acceptance/general/IntegrationsCest.php
@@ -136,6 +136,11 @@ class IntegrationsCest
 	public function _passed(AcceptanceTester $I)
 	{
 		$I->deactivateConvertKitPlugin($I);
-		$I->deactivateThirdPartyPlugin($I, 'wpforms-lite');
+
+		// We don't use deactivateThirdPartyPlugin(), as this checks for PHP warnings/errors.
+		// WPForms throws a 502 bad gateway on deactivation, which is outside of our control
+		// and would result in the test not completing.
+		$I->amOnPluginsPage();
+		$I->deactivatePlugin('wpforms-lite');
 	}
 }

--- a/tests/acceptance/general/UpgradePathsCest.php
+++ b/tests/acceptance/general/UpgradePathsCest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Tests edge cases when upgrading between specific ConvertKit Plugin versions.
+ *
+ * @since   1.5.0
+ */
+class UpgradePathsCest
+{
+	/**
+	 * Check that ConvertKit Settings stored on a WPForms Form using < 1.5.0 are correctly
+	 * migrated to the WPForms > Settings > Integrations tab.
+	 *
+	 * @since   1.5.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testMigrateFormSettingsToIntegration(AcceptanceTester $I)
+	{
+		// Activate WPForms.
+		$I->activateThirdPartyPlugin($I, 'wpforms-lite');
+
+		// Create Form, as if it were created with this Plugin < 1.5.0.
+		$wpFormsID = $I->createWPFormsFormForMigration($I);
+
+		// Activate Plugin, which triggers the automatic settings to integrations migration process.
+		$I->activateConvertKitPlugin($I);
+
+		// Confirm that the version number now exists in the options table.
+		$I->seeOptionInDatabase('integrate_convertkit_wpforms_version');
+
+		// Confirm that an integration is now registered for ConvertKit.
+		$providers = $I->grabOptionFromDatabase('wpforms_providers');
+		$I->assertArrayHasKey('convertkit', $providers);
+
+		// Get first integration for ConvertKit, and confirm it has the expected array structure and values.
+		$account = reset( $providers['convertkit'] );
+		$I->assertArrayHasKey('api_key', $account);
+		$I->assertArrayHasKey('api_secret', $account);
+		$I->assertArrayHasKey('label', $account);
+		$I->assertArrayHasKey('date', $account);
+		$I->assertEquals($_ENV['CONVERTKIT_API_KEY'], $account['api_key']);
+		$I->assertEquals('ConvertKit', $account['label']);
+
+		// Create a Page with the WPForms shortcode as its content.
+		$pageID = $I->createPageWithWPFormsShortcode($I, $wpFormsID);
+
+		// Define Name and Email Address for this Test.
+		$firstName    = 'First';
+		$lastName     = 'Last';
+		$emailAddress = $I->generateEmailAddress();
+
+		// Logout as the WordPress Administrator.
+		$I->logOut();
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Complete Form Fields.
+		$I->fillField('input.wpforms-field-name-first', $firstName);
+		$I->fillField('input.wpforms-field-name-last', $lastName);
+		$I->fillField('.wpforms-field-email input[type=email]', $emailAddress);
+
+		// Submit Form.
+		$I->click('Submit');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm submission was successful.
+		$I->waitForElementVisible('.wpforms-confirmation-scroll');
+		$I->seeInSource('Thanks for contacting us! We will be in touch with you shortly.');
+
+		// Check API to confirm subscriber was sent.
+		$I->apiCheckSubscriberExists($I, $emailAddress, $firstName . ' ' . $lastName);
+	}
+}


### PR DESCRIPTION
## Summary

Adds tests for https://github.com/ConvertKit/convertkit-wpforms/pull/4, covering:
- registering the integration,
- using the integration on a WPForms Form, to subscribe to a ConvertKit Form, with tags/custom field tests
- backward compatibility tests to ensure existing `ck-tag` and `ck-custom-{name}` CSS classes are honored

[This PR](https://github.com/ConvertKit/convertkit-wpforms/pull/6) covers migrating ConvertKit settings (API Key, Form ID, Name Field, Email Field) to the new integration method

## Testing

Tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)