### PR TITLE
Migrate ConvertKit Form Settings to Integration

### DIFF
--- a/includes/class-integrate-convertkit-wpforms-setup.php
+++ b/includes/class-integrate-convertkit-wpforms-setup.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * Plugin activation, update and deactivation class.
+ *
+ * @package Integrate_ConvertKit_WPForms
+ * @author  ConvertKit
+ */
+
+/**
+ * Runs any steps required on plugin activation, update and deactivation.
+ *
+ * @package Integrate_ConvertKit_WPForms
+ * @author  ConvertKit
+ * @version 1.5.0
+ */
+class Integrate_ConvertKit_WPForms_Setup {
+
+	/**
+	 * Runs routines when the Plugin version has been updated.
+	 *
+	 * @since   1.5.0
+	 */
+	public function update() {
+
+		// Get installed Plugin version.
+		$current_version = get_option( 'integrate_convertkit_wpforms_version' );
+
+		// If the version number matches the plugin version, no update routines
+		// need to run.
+		if ( $current_version === INTEGRATE_CONVERTKIT_WPFORMS_VERSION ) {
+			return;
+		}
+
+		/**
+		 * 1.5.0: Migrate API settings from individual forms to integrations.
+		 */
+		if ( ! $current_version || version_compare( $current_version, '1.5.0', '<' ) ) {
+			$this->migrate_settings_from_forms_to_integrations();
+		}
+
+		// Update the installed version number in the options table.
+		update_option( 'integrate_convertkit_wpforms_version', INTEGRATE_CONVERTKIT_WPFORMS_VERSION );
+
+	}
+
+	/**
+	 * 1.5.0+: For each WPForms Form that has ConvertKit settings defined (API Key, Form ID etc), migrate
+	 * those settings to a provider connection (WPForms > ), and configures the WPForms Form to use the
+	 * integration connection instead of the form settings.
+	 *
+	 * @since   1.5.0
+	 */
+	private function migrate_settings_from_forms_to_integrations() {
+
+		// Bail if the WPForms handler class isn't available.
+		if ( ! class_exists( 'WPForms_Form_Handler' ) ) {
+			return;
+		}
+
+		// Get all forms.
+		$form_handler = new WPForms_Form_Handler();
+		$forms        = $form_handler->get();
+
+		// Bail if no WPForms Forms exist.
+		if ( ! is_array( $forms ) ) {
+			return;
+		}
+		if ( count( $forms ) === 0 ) {
+			return;
+		}
+
+		// For each form, inspect its settings to determine if < 1.5.0 ConvertKit settings exist in the Form.
+		foreach ( $forms as $form ) {
+			// Decode settings into array.
+			$data = wpforms_decode( $form->post_content );
+
+			// Skip if this Form already has a ConvertKit provider configured.
+			// This shouldn't be the case for upgrades to 1.5.0+, but it's a useful
+			// sanity check.
+			if ( array_key_exists( 'providers', $data ) && array_key_exists( 'convertkit', $data['providers'] ) ) {
+				continue;
+			}
+
+			// Bail if the API Key or Form ID settings don't exist or are empty.
+			if ( ! array_key_exists( 'be_convertkit_api', $data['settings'] ) ) {
+				continue;
+			}
+			if ( empty( $data['settings']['be_convertkit_api'] ) ) {
+				continue;
+			}
+			if ( ! array_key_exists( 'be_convertkit_form_id', $data['settings'] ) ) {
+				continue;
+			}
+			if ( empty( $data['settings']['be_convertkit_form_id'] ) ) {
+				continue;
+			}
+
+			// Search WPForms provider accounts to see if an account exists for this ConvertKit API Key.
+			$account_id = $this->wpforms_get_provider_account_by_api_key( $data['settings']['be_convertkit_api'] );
+
+			// If no account exists, register a new ConvertKit provider account using this API Key.
+			if ( ! $account_id ) {
+				$account_id = $this->wpforms_register_account( $data['settings']['be_convertkit_api'] );
+			}
+
+			// Define the ConvertKit provider settings in the form.
+			$data['providers']['convertkit'] = array(
+				'connection_' . uniqid() => array(
+					'connection_name' => 'ConvertKit',
+					'account_id'      => $account_id,
+					'list_id'         => $data['settings']['be_convertkit_form_id'],
+					'fields'          => array(
+						'email' => $data['settings']['be_convertkit_field_email'] . '.value.email',
+						'name'  => $data['settings']['be_convertkit_field_first_name'] . '.value.text',
+					),
+				),
+			);
+
+			// Remove deprecated ConvertKit form settings.
+			unset(
+				$data['settings']['be_convertkit_api'],
+				$data['settings']['be_convertkit_form_id'],
+				$data['settings']['be_convertkit_field_first_name'],
+				$data['settings']['be_convertkit_field_email']
+			);
+
+			// Save data back to the form.
+			$form_handler->update( $form->ID, $data );
+		}
+
+	}
+
+	/**
+	 * Returns the account ID for the ConvertKit provider registered in WPForms
+	 * for the given ConvertKit API Key.
+	 *
+	 * Returns false if no provider is registered with the given API Key.
+	 *
+	 * @since   1.5.0
+	 *
+	 * @param   string $api_key    ConvertKit API Key.
+	 * @return  bool|string         false | Account ID.
+	 */
+	private function wpforms_get_provider_account_by_api_key( $api_key ) {
+
+		// Get all ConvertKit connections that are registered.
+		$connections = wpforms_get_providers_options( 'convertkit' );
+
+		// If no existing connections exist, register one now and return its ID.
+		if ( ! $connections ) {
+			return false;
+		}
+
+		foreach ( $connections as $id => $connection ) {
+			// If the connection's API Key matches the one we want to register a connection for,
+			// we can use the existing connection.
+			if ( $connection['api_key'] === $api_key ) {
+				return $id;
+			}
+		}
+
+		// If here, we have no existing ConvertKit connection for this API Key.
+		return false;
+
+	}
+
+	/**
+	 * Returns a ConvertKit provider account in WPForms for the given ConvertKit API Key.
+	 *
+	 * @since   1.5.0
+	 *
+	 * @param   string $api_key    ConvertKit API Key.
+	 * @return  string              Account ID
+	 */
+	private function wpforms_register_account( $api_key ) {
+
+		// wpforms_update_providers_options() doesn't return the generated ID
+		// for a new provider account, so we mimic how they generate an ID
+		// and return it.
+		$id = uniqid();
+
+		wpforms_update_providers_options(
+			'convertkit',
+			array(
+				'api_key'    => $api_key,
+				'api_secret' => '',
+				'label'      => 'ConvertKit',
+				'date'       => strtotime( 'now' ),
+			),
+			$id
+		);
+
+		return $id;
+
+	}
+
+}

--- a/includes/class-integrate-convertkit-wpforms.php
+++ b/includes/class-integrate-convertkit-wpforms.php
@@ -55,9 +55,24 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 		$this->priority = 14;
 		$this->icon     = INTEGRATE_CONVERTKIT_WPFORMS_URL . 'resources/backend/images/convertkit-logomark-red.svg';
 
+		// Run update routine.
+		add_action( 'init', array( $this, 'update' ) );
+
 		if ( is_admin() ) {
 			add_filter( "wpforms_providers_provider_settings_formbuilder_display_content_default_screen_{$this->slug}", array( $this, 'builder_settings_default_content' ) );
 		}
+
+	}
+
+	/**
+	 * Runs update/upgrade routines between Plugin versions.
+	 *
+	 * @since   1.5.0
+	 */
+	public function update() {
+
+		$setup = new Integrate_ConvertKit_WPForms_Setup();
+		$setup->update();
 
 	}
 

--- a/integrate-convertkit-wpforms.php
+++ b/integrate-convertkit-wpforms.php
@@ -3,7 +3,7 @@
  * Plugin Name: Integrate ConvertKit and WPForms
  * Plugin URI:  https://convertkit.com
  * Description: Create ConvertKit signup forms using WPForms
- * Version:     1.4.1
+ * Version:     1.5.0
  * Author:      ConvertKit
  * Author URI:  https://convertkit.com
  * Text Domain: integrate-convertkit-wpforms
@@ -36,7 +36,7 @@ define( 'INTEGRATE_CONVERTKIT_WPFORMS_NAME', 'ConvertKitWPForms' ); // Used for 
 define( 'INTEGRATE_CONVERTKIT_WPFORMS_FILE', plugin_basename( __FILE__ ) );
 define( 'INTEGRATE_CONVERTKIT_WPFORMS_URL', plugin_dir_url( __FILE__ ) );
 define( 'INTEGRATE_CONVERTKIT_WPFORMS_PATH', __DIR__ );
-define( 'INTEGRATE_CONVERTKIT_WPFORMS_VERSION', '1.4.0' );
+define( 'INTEGRATE_CONVERTKIT_WPFORMS_VERSION', '1.5.0' );
 
 // Load shared classes, if they have not been included by another ConvertKit Plugin.
 if ( ! class_exists( 'ConvertKit_API' ) ) {
@@ -51,6 +51,7 @@ function integrate_convertkit_wpforms() {
 	load_plugin_textdomain( 'integrate-convertkit-wpforms', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
 
 	require_once plugin_dir_path( __FILE__ ) . '/includes/class-integrate-convertkit-wpforms-api.php';
+	require_once plugin_dir_path( __FILE__ ) . '/includes/class-integrate-convertkit-wpforms-setup.php';
 	require_once plugin_dir_path( __FILE__ ) . '/includes/class-integrate-convertkit-wpforms.php';
 
 }

--- a/tests/_support/Helper/Acceptance/WPForms.php
+++ b/tests/_support/Helper/Acceptance/WPForms.php
@@ -34,6 +34,131 @@ class WPForms extends \Codeception\Module
 	}
 
 	/**
+	 * Creates a WPForms Form with ConvertKit Settings, as if it were created
+	 * in 1.4.1 or older.
+	 *
+	 * @since   1.5.0
+	 *
+	 * @param   AcceptanceTester $I AcceptanceTester.
+	 * @return  int                 Form ID.
+	 */
+	public function createWPFormsFormForMigration($I)
+	{
+		// Create Form, as if it were created with this Plugin < 1.5.0.
+		return $I->havePostInDatabase(
+			[
+				'post_type'    => 'wpforms',
+				'post_status'  => 'publish',
+				'post_title'   => 'Migrate form',
+				'post_name'    => 'migrate-form',
+				'post_content' => json_encode( // phpcs:ignore WordPress.WP.AlternativeFunctions
+					array(
+						'fields'   => array(
+							array(
+								'id'                 => '0',
+								'type'               => 'name',
+								'label'              => 'Name',
+								'format'             => 'first-last',
+								'description'        => '',
+								'required'           => '1',
+								'size'               => 'medium',
+								'simple_placeholder' => '',
+								'simple_default'     => '',
+								'first_placeholder'  => '',
+								'first_default'      => '',
+								'middle_placeholder' => '',
+								'middle_default'     => '',
+								'last_placeholder'   => '',
+								'last_default'       => '',
+								'css'                => '',
+							),
+							array(
+								'id'                       => '1',
+								'type'                     => 'email',
+								'label'                    => 'Email',
+								'description'              => '',
+								'required'                 => '1',
+								'size'                     => 'medium',
+								'placeholder'              => '',
+								'confirmation_placeholder' => '',
+								'default_value'            => false,
+								'filter_type'              => '',
+								'allowlist'                => '',
+								'denylist'                 => '',
+								'css'                      => '',
+							),
+							array(
+								'id'            => '2',
+								'type'          => 'textarea',
+								'label'         => 'Comment or Message',
+								'description'   => '',
+								'size'          => 'medium',
+								'placeholder'   => '',
+								'limit_count'   => '1',
+								'limit_mode'    => 'characters',
+								'default_value' => '',
+								'css'           => '',
+							),
+							array(
+								'id'            => '3',
+								'type'          => 'text',
+								'label'         => 'Tag ID',
+								'description'   => '',
+								'size'          => 'medium',
+								'placeholder'   => '',
+								'limit_count'   => '1',
+								'limit_mode'    => 'characters',
+								'default_value' => '',
+								'input_mask'    => '',
+								'css'           => '',
+							),
+						),
+						'id'       => '2',
+						'field_id' => 4,
+						'settings' => array(
+							'be_convertkit_api'         => $_ENV['CONVERTKIT_API_KEY'],
+							'be_convertkit_form_id'     => $_ENV['CONVERTKIT_API_FORM_ID'],
+							'be_convertkit_field_first_name' => '0',
+							'be_convertkit_field_email' => '1',
+							'form_title'                => 'Simple Contact Form',
+							'form_desc'                 => '',
+							'submit_text'               => 'Submit',
+							'submit_text_processing'    => 'Sending...',
+							'form_class'                => '',
+							'submit_class'              => '',
+							'ajax_submit'               => '1',
+							'notification_enable'       => '1',
+							'notifications'             => array(
+								1 => array(
+									'email'          => '{admin_email}',
+									'subject'        => 'New Entry: Simple Contact Form',
+									'sender_name'    => 'convertkit',
+									'sender_address' => '{admin_email}',
+									'replyto'        => '{field_id="1"}',
+									'message'        => '{all_fields}',
+								),
+							),
+							'confirmations'             => array(
+								1 => array(
+									'type'           => 'message',
+									'message'        => '<p>Thanks for contacting us! We will be in touch with you shortly.</p>',
+									'message_scroll' => '1',
+									'redirect'       => '',
+								),
+							),
+							'antispam'                  => '1',
+							'form_tags'                 => array(),
+						),
+						'meta'     => array(
+							'template' => 'simple-contact-form-template',
+						),
+					)
+				),
+			]
+		);
+	}
+
+	/**
 	 * Creates a WPForms Form.
 	 *
 	 * @since   1.4.0

--- a/tests/acceptance/general/UpgradePathsCest.php
+++ b/tests/acceptance/general/UpgradePathsCest.php
@@ -20,15 +20,7 @@ class UpgradePathsCest
 		$I->activateThirdPartyPlugin($I, 'wpforms-lite');
 
 		// Create Form, as if it were created with this Plugin < 1.5.0.
-		$wpFormsID = $I->havePostInDatabase(
-			[
-				'post_type'    => 'wpforms',
-				'post_status'  => 'publish',
-				'post_title'   => 'Migrate form',
-				'post_name'    => 'migrate-form',
-				'post_content' => '{"fields":[{"id":"0","type":"name","label":"Name","format":"first-last","description":"","required":"1","size":"medium","simple_placeholder":"","simple_default":"","first_placeholder":"","first_default":"","middle_placeholder":"","middle_default":"","last_placeholder":"","last_default":"","css":""},{"id":"1","type":"email","label":"Email","description":"","required":"1","size":"medium","placeholder":"","confirmation_placeholder":"","default_value":false,"filter_type":"","allowlist":"","denylist":"","css":""},{"id":"2","type":"textarea","label":"Comment or Message","description":"","size":"medium","placeholder":"","limit_count":"1","limit_mode":"characters","default_value":"","css":""},{"id":"3","type":"text","label":"Tag ID","description":"","size":"medium","placeholder":"","limit_count":"1","limit_mode":"characters","default_value":"","input_mask":"","css":""}],"id":"2","field_id":4,"settings":{"be_convertkit_api":"' . $_ENV['CONVERTKIT_API_KEY'] . '","be_convertkit_form_id":"' . $_ENV['CONVERTKIT_API_FORM_ID'] . '","be_convertkit_field_first_name":"0","be_convertkit_field_email":"1","form_title":"Simple Contact Form","form_desc":"","submit_text":"Submit","submit_text_processing":"Sending...","form_class":"","submit_class":"","ajax_submit":"1","notification_enable":"1","notifications":{"1":{"email":"{admin_email}","subject":"New Entry: Simple Contact Form","sender_name":"convertkit","sender_address":"{admin_email}","replyto":"{field_id=\"1\"}","message":"{all_fields}"}},"confirmations":{"1":{"type":"message","message":"<p>Thanks for contacting us! We will be in touch with you shortly.<\/p>","message_scroll":"1","redirect":""}},"antispam":"1","form_tags":[]},"meta":{"template":"simple-contact-form-template"}}',
-			]
-		);
+		$wpFormsID = $I->createWPFormsFormForMigration($I);
 
 		// Activate Plugin, which triggers the automatic settings to integrations migration process.
 		$I->activateConvertKitPlugin($I);

--- a/tests/acceptance/general/UpgradePathsCest.php
+++ b/tests/acceptance/general/UpgradePathsCest.php
@@ -26,13 +26,13 @@ class UpgradePathsCest
 				'post_status'  => 'publish',
 				'post_title'   => 'Migrate form',
 				'post_name'    => 'migrate-form',
-				'post_content' => '{"fields":[{"id":"0","type":"name","label":"Name","format":"first-last","description":"","required":"1","size":"medium","simple_placeholder":"","simple_default":"","first_placeholder":"","first_default":"","middle_placeholder":"","middle_default":"","last_placeholder":"","last_default":"","css":""},{"id":"1","type":"email","label":"Email","description":"","required":"1","size":"medium","placeholder":"","confirmation_placeholder":"","default_value":false,"filter_type":"","allowlist":"","denylist":"","css":""},{"id":"2","type":"textarea","label":"Comment or Message","description":"","size":"medium","placeholder":"","limit_count":"1","limit_mode":"characters","default_value":"","css":""},{"id":"3","type":"text","label":"Tag ID","description":"","size":"medium","placeholder":"","limit_count":"1","limit_mode":"characters","default_value":"","input_mask":"","css":""}],"id":"2","field_id":4,"settings":{"be_convertkit_api":"'.$_ENV['CONVERTKIT_API_KEY'].'","be_convertkit_form_id":"'.$_ENV['CONVERTKIT_API_FORM_ID'].'","be_convertkit_field_first_name":"0","be_convertkit_field_email":"1","form_title":"Simple Contact Form","form_desc":"","submit_text":"Submit","submit_text_processing":"Sending...","form_class":"","submit_class":"","ajax_submit":"1","notification_enable":"1","notifications":{"1":{"email":"{admin_email}","subject":"New Entry: Simple Contact Form","sender_name":"convertkit","sender_address":"{admin_email}","replyto":"{field_id=\"1\"}","message":"{all_fields}"}},"confirmations":{"1":{"type":"message","message":"<p>Thanks for contacting us! We will be in touch with you shortly.<\/p>","message_scroll":"1","redirect":""}},"antispam":"1","form_tags":[]},"meta":{"template":"simple-contact-form-template"}}',
+				'post_content' => '{"fields":[{"id":"0","type":"name","label":"Name","format":"first-last","description":"","required":"1","size":"medium","simple_placeholder":"","simple_default":"","first_placeholder":"","first_default":"","middle_placeholder":"","middle_default":"","last_placeholder":"","last_default":"","css":""},{"id":"1","type":"email","label":"Email","description":"","required":"1","size":"medium","placeholder":"","confirmation_placeholder":"","default_value":false,"filter_type":"","allowlist":"","denylist":"","css":""},{"id":"2","type":"textarea","label":"Comment or Message","description":"","size":"medium","placeholder":"","limit_count":"1","limit_mode":"characters","default_value":"","css":""},{"id":"3","type":"text","label":"Tag ID","description":"","size":"medium","placeholder":"","limit_count":"1","limit_mode":"characters","default_value":"","input_mask":"","css":""}],"id":"2","field_id":4,"settings":{"be_convertkit_api":"' . $_ENV['CONVERTKIT_API_KEY'] . '","be_convertkit_form_id":"' . $_ENV['CONVERTKIT_API_FORM_ID'] . '","be_convertkit_field_first_name":"0","be_convertkit_field_email":"1","form_title":"Simple Contact Form","form_desc":"","submit_text":"Submit","submit_text_processing":"Sending...","form_class":"","submit_class":"","ajax_submit":"1","notification_enable":"1","notifications":{"1":{"email":"{admin_email}","subject":"New Entry: Simple Contact Form","sender_name":"convertkit","sender_address":"{admin_email}","replyto":"{field_id=\"1\"}","message":"{all_fields}"}},"confirmations":{"1":{"type":"message","message":"<p>Thanks for contacting us! We will be in touch with you shortly.<\/p>","message_scroll":"1","redirect":""}},"antispam":"1","form_tags":[]},"meta":{"template":"simple-contact-form-template"}}',
 			]
 		);
 
 		// Activate Plugin, which triggers the automatic settings to integrations migration process.
 		$I->activateConvertKitPlugin($I);
-		
+
 		// Confirm that the version number now exists in the options table.
 		$I->seeOptionInDatabase('integrate_convertkit_wpforms_version');
 
@@ -82,6 +82,6 @@ class UpgradePathsCest
 		$I->seeInSource('Thanks for contacting us! We will be in touch with you shortly.');
 
 		// Check API to confirm subscriber was sent.
-		$I->apiCheckSubscriberExists($I, $emailAddress, $firstName.' '.$lastName);
+		$I->apiCheckSubscriberExists($I, $emailAddress, $firstName . ' ' . $lastName);
 	}
 }

--- a/tests/acceptance/general/UpgradePathsCest.php
+++ b/tests/acceptance/general/UpgradePathsCest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Tests edge cases when upgrading between specific ConvertKit Plugin versions.
+ *
+ * @since   1.5.0
+ */
+class UpgradePathsCest
+{
+	/**
+	 * Check that ConvertKit Settings stored on a WPForms Form using < 1.5.0 are correctly
+	 * migrated to the WPForms > Settings > Integrations tab.
+	 *
+	 * @since   1.5.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testMigrateFormSettingsToIntegration(AcceptanceTester $I)
+	{
+		// Activate WPForms.
+		$I->activateThirdPartyPlugin($I, 'wpforms-lite');
+
+		// Create Form, as if it were created with this Plugin < 1.5.0.
+		$wpFormsID = $I->havePostInDatabase(
+			[
+				'post_type'    => 'wpforms',
+				'post_status'  => 'publish',
+				'post_title'   => 'Migrate form',
+				'post_name'    => 'migrate-form',
+				'post_content' => '{"fields":[{"id":"0","type":"name","label":"Name","format":"first-last","description":"","required":"1","size":"medium","simple_placeholder":"","simple_default":"","first_placeholder":"","first_default":"","middle_placeholder":"","middle_default":"","last_placeholder":"","last_default":"","css":""},{"id":"1","type":"email","label":"Email","description":"","required":"1","size":"medium","placeholder":"","confirmation_placeholder":"","default_value":false,"filter_type":"","allowlist":"","denylist":"","css":""},{"id":"2","type":"textarea","label":"Comment or Message","description":"","size":"medium","placeholder":"","limit_count":"1","limit_mode":"characters","default_value":"","css":""},{"id":"3","type":"text","label":"Tag ID","description":"","size":"medium","placeholder":"","limit_count":"1","limit_mode":"characters","default_value":"","input_mask":"","css":""}],"id":"2","field_id":4,"settings":{"be_convertkit_api":"'.$_ENV['CONVERTKIT_API_KEY'].'","be_convertkit_form_id":"'.$_ENV['CONVERTKIT_API_FORM_ID'].'","be_convertkit_field_first_name":"0","be_convertkit_field_email":"1","form_title":"Simple Contact Form","form_desc":"","submit_text":"Submit","submit_text_processing":"Sending...","form_class":"","submit_class":"","ajax_submit":"1","notification_enable":"1","notifications":{"1":{"email":"{admin_email}","subject":"New Entry: Simple Contact Form","sender_name":"convertkit","sender_address":"{admin_email}","replyto":"{field_id=\"1\"}","message":"{all_fields}"}},"confirmations":{"1":{"type":"message","message":"<p>Thanks for contacting us! We will be in touch with you shortly.<\/p>","message_scroll":"1","redirect":""}},"antispam":"1","form_tags":[]},"meta":{"template":"simple-contact-form-template"}}',
+			]
+		);
+
+		// Activate Plugin, which triggers the automatic settings to integrations migration process.
+		$I->activateConvertKitPlugin($I);
+		
+		// Confirm that the version number now exists in the options table.
+		$I->seeOptionInDatabase('integrate_convertkit_wpforms_version');
+
+		// Confirm that an integration is now registered for ConvertKit.
+		$providers = $I->grabOptionFromDatabase('wpforms_providers');
+		$I->assertArrayHasKey('convertkit', $providers);
+
+		// Get first integration for ConvertKit, and confirm it has the expected array structure and values.
+		$account = reset( $providers['convertkit'] );
+		$I->assertArrayHasKey('api_key', $account);
+		$I->assertArrayHasKey('api_secret', $account);
+		$I->assertArrayHasKey('label', $account);
+		$I->assertArrayHasKey('date', $account);
+		$I->assertEquals($_ENV['CONVERTKIT_API_KEY'], $account['api_key']);
+		$I->assertEquals('ConvertKit', $account['label']);
+
+		// Create a Page with the WPForms shortcode as its content.
+		$pageID = $I->createPageWithWPFormsShortcode($I, $wpFormsID);
+
+		// Define Name and Email Address for this Test.
+		$firstName    = 'First';
+		$lastName     = 'Last';
+		$emailAddress = $I->generateEmailAddress();
+
+		// Logout as the WordPress Administrator.
+		$I->logOut();
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Complete Form Fields.
+		$I->fillField('input.wpforms-field-name-first', $firstName);
+		$I->fillField('input.wpforms-field-name-last', $lastName);
+		$I->fillField('.wpforms-field-email input[type=email]', $emailAddress);
+
+		// Submit Form.
+		$I->click('Submit');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm submission was successful.
+		$I->waitForElementVisible('.wpforms-confirmation-scroll');
+		$I->seeInSource('Thanks for contacting us! We will be in touch with you shortly.');
+
+		// Check API to confirm subscriber was sent.
+		$I->apiCheckSubscriberExists($I, $emailAddress, $firstName.' '.$lastName);
+	}
+}


### PR DESCRIPTION
## Summary

- Automatically migrates ConvertKit Settings created in <= 1.4.1 to the new integration / provider system, including field mappings.
- Runs a test to confirm that a WPForms Form with ConvertKit Settings correctly migrate and the subscriber is subscribed when the form is submitted.

## Testing

Tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)