### PR TITLE
Add PHPStan for Static Analysis

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -119,3 +119,8 @@ jobs:
       - name: Run WordPress Coding Standards
         working-directory: ${{ env.PLUGIN_DIR }}
         run: php vendor/bin/phpcs ./ --standard=phpcs.xml -v -s
+
+      # Run PHPStan for static analysis.
+      - name: Run PHPStan Static Analysis
+        working-directory: ${{ env.PLUGIN_DIR }}
+        run: php vendor/bin/phpstan --memory-limit=1024M

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -30,7 +30,7 @@ jobs:
       DB_USER: root
       DB_PASS: root
       DB_HOST: localhost
-      INSTALL_PLUGINS: "classic-editor" # Don't include this repository's Plugin here.
+      INSTALL_PLUGINS: "classic-editor wpforms-lite" # Don't include this repository's Plugin here.
 
     # Defines the WordPress and PHP Versions matrix to run tests on.
     strategy:

--- a/includes/class-integrate-convertkit-wpforms-api.php
+++ b/includes/class-integrate-convertkit-wpforms-api.php
@@ -17,9 +17,9 @@ class Integrate_ConvertKit_WPForms_API extends ConvertKit_API {
 	/**
 	 * Holds the log class for writing to the log file
 	 *
-	 * @var bool
+	 * @var bool|ConvertKit_Log
 	 */
-	public $log = false; // @phpstan-ignore-line
+	public $log = false;
 
 	/**
 	 * Holds an array of error messages, localized to the plugin
@@ -51,7 +51,7 @@ class Integrate_ConvertKit_WPForms_API extends ConvertKit_API {
 
 		// Setup logging class if the required parameters exist.
 		if ( $this->debug && $this->plugin_path !== false ) {
-			$this->log = new WC_Logger();
+			$this->log = new ConvertKit_Log( $this->plugin_path );
 		}
 
 		// Define translatable / localized error strings.

--- a/integrate-convertkit-wpforms.php
+++ b/integrate-convertkit-wpforms.php
@@ -42,6 +42,9 @@ define( 'INTEGRATE_CONVERTKIT_WPFORMS_VERSION', '1.5.0' );
 if ( ! class_exists( 'ConvertKit_API' ) ) {
 	require_once INTEGRATE_CONVERTKIT_WPFORMS_PATH . '/vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-api.php';
 }
+if ( ! class_exists( 'ConvertKit_Log' ) ) {
+    require_once INTEGRATE_CONVERTKIT_WPFORMS_PATH . '/vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-log.php';
+}
 
 /**
  * Load the class

--- a/integrate-convertkit-wpforms.php
+++ b/integrate-convertkit-wpforms.php
@@ -43,7 +43,7 @@ if ( ! class_exists( 'ConvertKit_API' ) ) {
 	require_once INTEGRATE_CONVERTKIT_WPFORMS_PATH . '/vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-api.php';
 }
 if ( ! class_exists( 'ConvertKit_Log' ) ) {
-    require_once INTEGRATE_CONVERTKIT_WPFORMS_PATH . '/vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-log.php';
+	require_once INTEGRATE_CONVERTKIT_WPFORMS_PATH . '/vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-log.php';
 }
 
 /**

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,25 @@
+# PHPStan configuration for GitHub Actions.
+
+# Include PHPStan for WordPress configuration.
+includes:
+    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+
+# Parameters
+parameters:
+    # Paths to scan
+    # This should comprise of the base Plugin PHP file, plus directories that contain Plugin PHP files
+    paths:
+        - integrate-convertkit-wpforms.php
+        - includes/
+
+    # Files that include Plugin-specific PHP constants
+    bootstrapFiles:
+        - integrate-convertkit-wpforms.php
+
+    # Location of WordPress Plugins for PHPStan to scan, building symbols.
+    scanDirectories:
+        - /home/runner/work/convertkit-wpforms/convertkit-wpforms/wordpress/wp-content/plugins
+
+    # Should not need to edit anything below here
+    # Rule Level: https://phpstan.org/user-guide/rule-levels
+    level: 5

--- a/phpstan.neon.example
+++ b/phpstan.neon.example
@@ -1,0 +1,25 @@
+# PHPStan configuration for GitHub Actions.
+
+# Include PHPStan for WordPress configuration.
+includes:
+    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+
+# Parameters
+parameters:
+    # Paths to scan
+    # This should comprise of the base Plugin PHP file, plus directories that contain Plugin PHP files
+    paths:
+        - integrate-convertkit-wpforms.php
+        - includes/
+
+    # Files that include Plugin-specific PHP constants
+    bootstrapFiles:
+        - integrate-convertkit-wpforms.php
+
+    # Location of WordPress Plugins for PHPStan to scan, building symbols.
+    scanDirectories:
+        - /home/runner/work/convertkit-wpforms/convertkit-wpforms/wordpress/wp-content/plugins
+
+    # Should not need to edit anything below here
+    # Rule Level: https://phpstan.org/user-guide/rule-levels
+    level: 5


### PR DESCRIPTION
## Summary

Runs PHPStan for static analysis, includes configuration files and changes to pass PHPStan analysis, as we do for other ConvertKit Plugins 

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)