### PR TITLE
Generate .pot file and actions-filters docs

### DIFF
--- a/.scripts/build.sh
+++ b/.scripts/build.sh
@@ -1,0 +1,9 @@
+# Build ACTIONS-FILTERS.md
+php create-actions-filters-docs.php
+
+# Generate .pot file
+php -n $(which wp) i18n make-pot ../ ../languages/integrate-convertkit-wpforms.pot
+
+# Build ZIP file
+rm ../integrate-convertkit-wpforms.zip
+cd .. && zip -r integrate-convertkit-wpforms.zip . -x "*.git*" -x ".scripts/*" -x ".wordpress-org/*" -x "tests/*" -x "vendor/*" -x "*.distignore" -x "*.env.*" -x "*codeception.*" -x "composer.json" -x "composer.lock" -x "*.md" -x "log.txt" -x "phpcs.xml" -x "phpcs.tests.xml" -x "phpstan.neon" -x "phpstan.neon.dist" -x "phpstan.neon.example" -x "*.DS_Store"

--- a/.scripts/class-read-actions-filters.php
+++ b/.scripts/class-read-actions-filters.php
@@ -1,0 +1,455 @@
+<?php
+/**
+ * Reads all Actions and Filters from the Plugin.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+/**
+ * Reads all Actions and Filters from the Plugin.
+ *
+ * @since   1.0.0
+ */
+class Read_Actions_Filters {
+
+	/**
+	 * Extracts all instances of apply_filters() and do_action() calls from the specified folders and subfolders
+	 * PHP files.
+	 *
+	 * Results can be returned as an array or HTML.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param   mixed $folders                        WordPress Plugin/Theme Folder Path(s) (e.g. /path/to/your/wp/wp-content/plugins/plugin-name).
+	 * @param   bool  $extract_filters                Extract apply_filters() calls.
+	 * @param   bool  $extract_actions                Extract do_action() calls.
+	 * @param   bool  $return_format                  Return Format (html|array).
+	 * @param   mixed $prefix_required                Optional prefix string required on filters and actions for inclusion in resultset (false = don't filter any found filters/actions).
+	 * @param   mixed $prefix_required_replacement    Optional prefix string replacement, to use if $prefix_required is found (e.g. $this->base->plugin->name --> convertkit_).
+	 * @param   bool  $by_file                        Denote filters and actions by filename (false = group filters and actions if they appear across multiple files).
+	 * @return  mixed                                  Output
+	 */
+	public function run( $folders, $extract_filters = true, $extract_actions = true, $return_format = 'html', $prefix_required = false, $prefix_required_replacement = false, $by_file = false ) {
+
+		$php_files = array();
+
+		// Make $folders an array.
+		if ( ! is_array( $folders ) ) {
+			$folders = array( $folders );
+		}
+
+		// Iterate through folders.
+		foreach ( $folders as $folder ) {
+
+			// Check the target folder exists.
+			if ( ! is_dir( $folder ) ) {
+				continue;
+			}
+
+			// Iterate through the folder and subfolders, finding any PHP files.
+			foreach ( new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $folder ) ) as $filename ) {
+
+				// Ignore directories.
+				if ( is_dir( $filename ) ) {
+					continue;
+				}
+
+				// Check if a PHP file.
+				if ( substr( $filename, -4 ) !== '.php' ) {
+					continue;
+				}
+
+				$php_files[] = $filename;
+
+			}
+		}
+
+		// Check if any PHP files were found.
+		if ( count( $php_files ) === 0 ) {
+			return false;
+		}
+
+		// Iterate through PHP files, extracting apply_filters() and do_action() calls.
+		$filters = array();
+		$actions = array();
+		foreach ( $php_files as $file ) {
+			// Read file contents.
+			$h = fopen( $file, 'r' ); // phpcs:ignore WordPress.WP.AlternativeFunctions
+			if ( ! $h ) {
+				continue;
+			}
+			$contents = fread( $h, filesize( $file ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions
+			fclose( $h ); // phpcs:ignore WordPress.WP.AlternativeFunctions
+
+			// Get file name.
+			$file_only = str_replace( $folder, '', $file );
+
+			// Find all instances of apply_filters() and do_action().
+			if ( $extract_filters ) {
+				$filters = $this->find_matches( 'apply_filters', $filters, $contents, $file_only, html_entity_decode( $prefix_required ), $prefix_required_replacement, $by_file );
+			}
+			if ( $extract_actions ) {
+				$actions = $this->find_matches( 'do_action', $actions, $contents, $file_only, html_entity_decode( $prefix_required ), $prefix_required_replacement, $by_file );
+			}
+		}
+
+		// Return.
+		switch ( $return_format ) {
+			// Array.
+			case 'array':
+				return array(
+					'filters' => $filters,
+					'actions' => $actions,
+				);
+
+			// HTML.
+			default:
+				$html = '';
+				if ( $extract_filters && count( $filters ) > 0 ) {
+					$html .= $this->html( $filters, $by_file );
+				}
+				if ( $extract_actions && count( $actions ) > 0 ) {
+					$html .= $this->html( $actions, $by_file );
+				}
+
+				return $html;
+		}
+
+	}
+
+	/**
+	 * Performs a regex search on the given file contents, returning an array
+	 * of matches.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param   string $function_to_search             Function to search (apply_filters|do_action).
+	 * @param   string $results                        Existing Results.
+	 * @param   string $contents                       File Contents.
+	 * @param   string $file_only                      Filename (excluding full path).
+	 * @param   string $prefix_required                Optional prefix string required on filters and actions for inclusion in resultset (false = don't filter any found filters/actions).
+	 * @param   mixed  $prefix_required_replacement    Optional prefix string replacement, to use if $prefix_required is found (e.g. $this->base->plugin->name --> convertkit_).
+	 * @param   bool   $by_file                        Deliminate array results by file.
+	 * @return  array       Matches
+	 */
+	private function find_matches( $function_to_search, $results, $contents, $file_only, $prefix_required, $prefix_required_replacement = false, $by_file ) {
+
+		// Split the content into separate lines in an array.
+		$file_lines = explode( "\n", $contents );
+
+		// Items that we're searching for in the code.
+		$search = array(
+			'function'       => $function_to_search . '( ' . $prefix_required,
+			'docblock_open'  => '/**',
+			'docblock_close' => '*/',
+		);
+
+		// Array to store the last known positions of the docblock open and close lines.
+		$positions = array(
+			'docblock_open'  => 0,
+			'docblock_close' => 0,
+		);
+
+		// Iterate through each line of the file's code.
+		foreach ( $file_lines as $index => $line ) {
+			// Tidy up the line of code.
+			$line = trim( $line );
+
+			// If this line of code contains an opening or closing docblock, store its position and continue.
+			if ( $line === $search['docblock_open'] ) {
+				$positions['docblock_open'] = $index;
+				continue;
+			}
+			if ( $line === $search['docblock_close'] ) {
+				$positions['docblock_close'] = $index;
+				continue;
+			}
+
+			// Skip if this line doesn't contain what we're looking for.
+			if ( strpos( $line, $search['function'] ) === false ) {
+				continue;
+			}
+
+			// If here, we've found a function.
+			// Sanity check that we can find the filter / action.
+			preg_match( '/' . $function_to_search . '\((.*?)\)/s', $line, $matches );
+			if ( empty( $matches[0] ) ) {
+				continue;
+			}
+
+			// Build function array.
+			$function = array(
+				'name' => trim( substr( $matches[1], 0, ( strpos( $matches[1], ',' ) === false ? strlen( $matches[1] ) : strpos( $matches[1], ',' ) ) ) ),
+				'line' => $index,
+				'desc' => false,
+				'args' => array(),
+				'call' => $matches[0],
+			);
+
+			// Replace $prefix_required with $prefix_required_replacement, if specified.
+			if ( $prefix_required_replacement !== false ) {
+				$function['call'] = str_replace( $prefix_required, $prefix_required_replacement, $function['call'] );
+				$function['name'] = str_replace( $prefix_required, $prefix_required_replacement, $function['name'] );
+			}
+
+			// Trim out anything that isn't a letter, number, underscore or dash - such as a single quote.
+			$function['name'] = preg_replace( '/[^ \w-]/', '', $function['name'] );
+
+			// Use code to populate function arguments.
+			$args = explode( ',', str_replace( ')', '', $matches[0] ) );
+			unset( $args[0] );
+
+			foreach ( $args as $key => $arg ) {
+				// Tidy up the argument.
+				$args[ $key ] = trim( str_replace( 'this->', '', $arg ) );
+
+				// Add to the function arguments array.
+				$function['args'][ $args[ $key ] ] = array(
+					'type' => false,
+					'desc' => false,
+				);
+			}
+
+			// Check if there truly is a docblock immediately preceding the function.
+			// If so, use that to define the function arguments.
+			$docblock = '';
+			if ( $index - 1 === $positions['docblock_close'] ) {
+				// Docblock exists.
+				// Use docblock to populate function arguments.
+				$docblock = array_slice( $file_lines, $positions['docblock_open'], ( $positions['docblock_close'] - $positions['docblock_open'] + 1 ) );
+				$docblock = array_map( 'trim', $docblock );
+
+				// Parse docblock.
+				$docblock_results = $this->parse_docblock( $docblock );
+
+				// Merge results.
+				if ( $docblock_results['args'] !== false ) {
+					$function = array_merge( $function, $docblock_results );
+				}
+			}
+
+			// Define example usage call.
+			if ( stripos( $function['call'], 'apply_filters' ) !== false ) {
+				$function['call'] = 'add_filter( \'' . $function['name'] . '\', function( ' . trim( implode( ', ', array_map( 'trim', $args ) ) ) . ' ) {
+	// ... your code here
+	// Return value
+	return ' . trim( $args[1] ) . ';
+}, 10, ' . count( $args ) . ' );';
+			} elseif ( stripos( $function['call'], 'do_action' ) !== false ) {
+				$function['call'] = 'do_action( \'' . $function['name'] . '\', function( ' . trim( implode( ', ', array_map( 'trim', $args ) ) ) . ' ) {
+	// ... your code here
+}, 10, ' . count( $args ) . ' );';
+			}
+
+			// Add function to results array.
+			if ( $by_file ) {
+				$results[ $file_only ][ $function['name'] ] = $function;
+			} else {
+				$results[ $function['name'] ] = $function;
+			}
+		} // Close foreach code line loop.
+
+		return $results;
+
+	}
+
+	/**
+	 * Parses each line in the given docblock, returning an array
+	 * of results.
+	 *
+	 * @since   1.0.0
+	 *
+	 * @param   array $docblock   Docblock Lines.
+	 * @return  array               Docblock Data.
+	 */
+	private function parse_docblock( $docblock ) {
+
+		// Array for results.
+		$results = array(
+			'desc'  => false,
+			'since' => false,
+			'args'  => false,
+		);
+
+		// Iterate through lines.
+		foreach ( $docblock as $line ) {
+
+			if ( ! preg_match( '/@(\w+) (.*)$/', $line, $matches ) ) {
+				// This might be the description.
+				if ( $line === '/**' || $line === '*/' || $line === '*' ) {
+					continue;
+				}
+
+				// Description.
+				$results['desc'] .= str_replace( '*', '', $line );
+				continue;
+			}
+
+			// Add to the results array.
+			switch ( $matches[1] ) {
+
+				case 'since':
+					// This can only be defined once, so don't store the value as an array.
+					$results[ $matches[1] ] = trim( $matches[2] );
+					break;
+
+				case 'param':
+					// Split out the parameter, type and description by any space or tab.
+					$param_parts = preg_split( '/\s\s+/', trim( $matches[2] ) );
+					$param_parts = array_map( 'trim', $param_parts );
+
+					// Remove empty param parts, which might occur when spaces are used instead of tabs.
+					foreach ( $param_parts as $key => $param_part ) {
+						if ( empty( trim( $param_part ) ) ) {
+							unset( $param_parts[ $key ] );
+						}
+					}
+
+					// Rekey array.
+					$param_parts = array_values( $param_parts );
+
+					// If we don't have 3 values in the array, parsing went wrong
+					// - most likely because there's only a single space between
+					// the variable and its description (we expect 2 spaces or more).
+					if ( count( $param_parts ) === 2 ) {
+						list ( $var, $desc ) = explode( ' ', $param_parts[1] );
+						$param_parts         = array(
+							$param_parts[0],
+							trim( $var ),
+							trim( $desc ),
+						);
+					}
+
+					// Add docblock information to the arguments array
+					// If the variable is $this->..., remove this-> so we have
+					// more human readable vars.
+					$results['args'][ trim( str_replace( 'this->', '', $param_parts[1] ) ) ] = array(
+						'type' => $param_parts[0],
+						'desc' => $param_parts[ count( $param_parts ) - 1 ],
+					);
+					break;
+
+				default:
+					$results[ $matches[1] ][] = trim( $matches[2] );
+					break;
+			}
+		}
+
+		// Tidy up results.
+		$results['desc']  = trim( $results['desc'] );
+		$results['since'] = $results['since'][0];
+
+		// Return.
+		return $results;
+
+	}
+
+	/**
+	 * Returns a HTML table of the given results
+	 *
+	 * @since   1.0.0
+	 *
+	 * @param   array $results        Results.
+	 * @param   bool  $by_file        Deliminate results by file.
+	 * @return  string  HTML
+	 */
+	private function html( $results, $by_file ) {
+
+		$html = '';
+
+		// Generate title based on type.
+		if ( $by_file ) {
+			// Index.
+			$html .= '<table>
+				<thead>
+					<tr>
+						<th>File</th>
+						<th>Filter Name</th>
+						<th>Description</th>
+					</tr>
+				</thead>
+				<tbody>';
+
+			foreach ( $results as $file => $functions ) {
+				$html .= '<tr>
+						<td colspan="3">' . $file . '</td>
+					</tr>';
+
+				// Index.
+				foreach ( $functions as $function ) {
+					$html .= '<tr>
+						<td>&nbsp;</td>
+						<td><a href="#' . $function['name'] . '"><code>' . $function['name'] . '</code></a></td>
+						<td>' . $function['desc'] . '</td>
+					</tr>';
+				}
+			}
+
+			$html .= '
+					</tbody>
+				</table>';
+
+			// Functions.
+			foreach ( $results as $file => $functions ) {
+				// Remove relative path.
+				$file = str_replace( '../', '', $file );
+
+				// Function Details.
+				foreach ( $functions as $function ) {
+					// Function name.
+					$html .= '<h3 id="' . $function['name'] . '">
+						' . $function['name'] . '
+						<code>' . $file . '::' . $function['line'] . '</code>
+					</h3>';
+
+					// Description.
+					if ( $function['desc'] !== false ) {
+						$html .= '<h4>Overview</h4>
+						<p>' . $function['desc'] . '</p>';
+					}
+
+					// Parameters.
+					$html .= '<h4>Parameters</h4>
+					<table>
+						<thead>
+							<tr>
+								<th>Parameter</th>
+								<th>Type</th>
+								<th>Description</th>
+							</tr>
+						</thead>
+						<tbody>';
+
+					foreach ( $function['args'] as $arg => $arg_data ) {
+						$html .= '<tr>
+							<td>' . $arg . '</td>
+							<td>' . ( $arg_data['type'] !== false ? $arg_data['type'] : 'Unknown' ) . '</td>
+							<td>' . ( $arg_data['desc'] !== false ? $arg_data['desc'] : 'N/A' ) . '</td>
+						</tr>';
+					}
+
+					$html .= '
+						</tbody>
+					</table>';
+
+					// Usage.
+					if ( $function['call'] !== false ) {
+						$html .= '<h4>Usage</h4>';
+						$html .= "\n";
+						$html .= '<pre>';
+						$html .= "\n";
+						$html .= $function['call'];
+						$html .= "\n";
+						$html .= '</pre>';
+						$html .= "\n";
+					}
+				}
+			}
+		}
+
+		return $html;
+
+	}
+
+}

--- a/.scripts/create-actions-filters-docs.php
+++ b/.scripts/create-actions-filters-docs.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Creates the ACTIONS-FILTERS.md markdown file, comprising of all ConvertKit
+ * action and filter hooks parsed from the Plugin code.
+ *
+ * @package Integrate_ConvertKit_WPForms
+ * @author ConvertKit
+ */
+
+// Setup Read Actions and Filters class.
+require_once 'class-read-actions-filters.php';
+$read_actions_filters = new Read_Actions_Filters();
+
+// Read Plugin filters.
+$filter_docs = $read_actions_filters->run(
+	// Define Plugin folders to include in Docs.
+	array(
+		'../admin',
+		'../includes',
+		'../views',
+	),
+	true, // Extract filters.
+	false, // Extract actions.
+	'html', // Return as HTML compatible with GitHub.
+	'\'be_convertkit_', // Only build Docs for actions starting with convertkit_.
+	false, // Change prefix.
+	true // Return by file.
+);
+$action_docs = $read_actions_filters->run(
+	// Define Plugin folders to include in Docs.
+	array(
+		'../admin',
+		'../includes',
+		'../views',
+	),
+	false, // Extract filters.
+	true, // Extract actions.
+	'html', // Return as HTML compatible with GitHub.
+	'\'be_convertkit_', // Only build Docs for actions starting with convertkit_.
+	false, // Change prefix.
+	true // Return by file.
+);
+
+// Build HTML.
+$html  = '<h1>Filters</h1>' . $filter_docs;
+$html .= '<h1>Actions</h1>' . $action_docs;
+
+// Write to file.
+file_put_contents( '../ACTIONS-FILTERS.md', $html ); // phpcs:ignore WordPress.WP.AlternativeFunctions

--- a/ACTIONS-FILTERS.md
+++ b/ACTIONS-FILTERS.md
@@ -1,0 +1,89 @@
+<h1>Filters</h1><table>
+				<thead>
+					<tr>
+						<th>File</th>
+						<th>Filter Name</th>
+						<th>Description</th>
+					</tr>
+				</thead>
+				<tbody><tr>
+						<td colspan="3">../includes/class-integrate-convertkit-wpforms.php</td>
+					</tr><tr>
+						<td>&nbsp;</td>
+						<td><a href="#be_convertkit_form_args"><code>be_convertkit_form_args</code></a></td>
+						<td></td>
+					</tr><tr>
+						<td>&nbsp;</td>
+						<td><a href="#be_convertkit_process_form"><code>be_convertkit_process_form</code></a></td>
+						<td></td>
+					</tr>
+					</tbody>
+				</table><h3 id="be_convertkit_form_args">
+						be_convertkit_form_args
+						<code>includes/class-integrate-convertkit-wpforms.php::217</code>
+					</h3><h4>Parameters</h4>
+					<table>
+						<thead>
+							<tr>
+								<th>Parameter</th>
+								<th>Type</th>
+								<th>Description</th>
+							</tr>
+						</thead>
+						<tbody><tr>
+							<td>$args</td>
+							<td>Unknown</td>
+							<td>N/A</td>
+						</tr><tr>
+							<td>$fields</td>
+							<td>Unknown</td>
+							<td>N/A</td>
+						</tr><tr>
+							<td>$form_data</td>
+							<td>Unknown</td>
+							<td>N/A</td>
+						</tr>
+						</tbody>
+					</table><h4>Usage</h4>
+<pre>
+add_filter( 'be_convertkit_form_args', function( $args, $fields, $form_data ) {
+	// ... your code here
+	// Return value
+	return $args;
+}, 10, 3 );
+</pre>
+<h3 id="be_convertkit_process_form">
+						be_convertkit_process_form
+						<code>includes/class-integrate-convertkit-wpforms.php::221</code>
+					</h3><h4>Parameters</h4>
+					<table>
+						<thead>
+							<tr>
+								<th>Parameter</th>
+								<th>Type</th>
+								<th>Description</th>
+							</tr>
+						</thead>
+						<tbody><tr>
+							<td>true</td>
+							<td>Unknown</td>
+							<td>N/A</td>
+						</tr><tr>
+							<td>$fields</td>
+							<td>Unknown</td>
+							<td>N/A</td>
+						</tr><tr>
+							<td>$form_data</td>
+							<td>Unknown</td>
+							<td>N/A</td>
+						</tr>
+						</tbody>
+					</table><h4>Usage</h4>
+<pre>
+add_filter( 'be_convertkit_process_form', function( true, $fields, $form_data ) {
+	// ... your code here
+	// Return value
+	return true;
+}, 10, 3 );
+</pre>
+<h1>Actions</h1>

--- a/languages/integrate-convertkit-wpforms.pot
+++ b/languages/integrate-convertkit-wpforms.pot
@@ -1,69 +1,193 @@
-# Copyright (C) 2017 Integrate ConvertKit and WPForms
-# This file is distributed under the same license as the Integrate ConvertKit and WPForms package.
+# Copyright (C) 2022 ConvertKit
+# This file is distributed under the GPLv2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Integrate ConvertKit and WPForms 1.0.3\n"
-"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/integrate-"
-"convertkit-wpforms\n"
-"POT-Creation-Date: 2017-04-13 15:38:58+00:00\n"
+"Project-Id-Version: Integrate ConvertKit and WPForms 1.5.0\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/convertkit-wpforms\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2017-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"POT-Creation-Date: 2022-12-15T16:44:23+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.6.0\n"
+"X-Domain: integrate-convertkit-wpforms\n"
 
-#: class-integrate-convertkit-wpforms.php:30
-#: class-integrate-convertkit-wpforms.php:41
-msgid "ConvertKit"
-msgstr ""
-
-#: class-integrate-convertkit-wpforms.php:46
-msgid "Don't have an account?"
-msgstr ""
-
-#: class-integrate-convertkit-wpforms.php:47
-msgid "Sign up now!"
-msgstr ""
-
-#: class-integrate-convertkit-wpforms.php:56
-msgid "ConvertKit API Key"
-msgstr ""
-
-#: class-integrate-convertkit-wpforms.php:64
-msgid "ConvertKit Form ID"
-msgstr ""
-
-#: class-integrate-convertkit-wpforms.php:72
-msgid "First Name"
-msgstr ""
-
-#: class-integrate-convertkit-wpforms.php:75
-#: class-integrate-convertkit-wpforms.php:87
-msgid "-- Select Field --"
-msgstr ""
-
-#: class-integrate-convertkit-wpforms.php:84
-msgid "Email Address"
-msgstr ""
-
-#. Plugin Name of the plugin/theme
+#. Plugin Name of the plugin
 msgid "Integrate ConvertKit and WPForms"
 msgstr ""
 
-#. Plugin URI of the plugin/theme
-msgid ""
-"https://www.billerickson.net/how-to-setup-convertkit-with-a-wordpress-form"
+#. Plugin URI of the plugin
+#. Author URI of the plugin
+msgid "https://convertkit.com"
 msgstr ""
 
-#. Description of the plugin/theme
+#. Description of the plugin
 msgid "Create ConvertKit signup forms using WPForms"
 msgstr ""
 
-#. Author of the plugin/theme
-msgid "Bill Erickson"
+#. Author of the plugin
+msgid "ConvertKit"
 msgstr ""
 
-#. Author URI of the plugin/theme
-msgid "https://www.billerickson.net"
+#: includes/class-integrate-convertkit-wpforms-api.php:61
+msgid "form_subscribe(): the form_id parameter is empty."
+msgstr ""
+
+#: includes/class-integrate-convertkit-wpforms-api.php:62
+msgid "form_subscribe(): the email parameter is empty."
+msgstr ""
+
+#: includes/class-integrate-convertkit-wpforms-api.php:64
+msgid "sequence_subscribe(): the sequence_id parameter is empty."
+msgstr ""
+
+#: includes/class-integrate-convertkit-wpforms-api.php:65
+msgid "sequence_subscribe(): the email parameter is empty."
+msgstr ""
+
+#: includes/class-integrate-convertkit-wpforms-api.php:67
+msgid "tag_subscribe(): the tag_id parameter is empty."
+msgstr ""
+
+#: includes/class-integrate-convertkit-wpforms-api.php:68
+msgid "tag_subscribe(): the email parameter is empty."
+msgstr ""
+
+#: includes/class-integrate-convertkit-wpforms-api.php:70
+msgid "get_subscriber_by_email(): the email parameter is empty."
+msgstr ""
+
+#. translators: Email Address
+#: includes/class-integrate-convertkit-wpforms-api.php:72
+msgid "get_subscriber_by_email(): No subscriber(s) exist in ConvertKit matching the email address %s."
+msgstr ""
+
+#: includes/class-integrate-convertkit-wpforms-api.php:74
+msgid "get_subscriber_by_id(): the subscriber_id parameter is empty."
+msgstr ""
+
+#: includes/class-integrate-convertkit-wpforms-api.php:76
+msgid "get_subscriber_tags(): the subscriber_id parameter is empty."
+msgstr ""
+
+#: includes/class-integrate-convertkit-wpforms-api.php:78
+msgid "unsubscribe(): the email parameter is empty."
+msgstr ""
+
+#: includes/class-integrate-convertkit-wpforms-api.php:80
+msgid "get_all_posts(): the posts_per_request parameter must be equal to or greater than 1."
+msgstr ""
+
+#: includes/class-integrate-convertkit-wpforms-api.php:81
+msgid "get_all_posts(): the posts_per_request parameter must be equal to or less than 50."
+msgstr ""
+
+#: includes/class-integrate-convertkit-wpforms-api.php:83
+msgid "get_posts(): the page parameter must be equal to or greater than 1."
+msgstr ""
+
+#: includes/class-integrate-convertkit-wpforms-api.php:84
+msgid "get_posts(): the per_page parameter must be equal to or greater than 1."
+msgstr ""
+
+#: includes/class-integrate-convertkit-wpforms-api.php:85
+msgid "get_posts(): the per_page parameter must be equal to or less than 50."
+msgstr ""
+
+#. translators: HTTP method
+#: includes/class-integrate-convertkit-wpforms-api.php:88
+msgid "API request method %s is not supported in ConvertKit_API class."
+msgstr ""
+
+#: includes/class-integrate-convertkit-wpforms-api.php:89
+msgid "Rate limit hit."
+msgstr ""
+
+#: includes/class-integrate-convertkit-wpforms-api.php:90
+msgid "The response from the API is not of the expected type array."
+msgstr ""
+
+#: includes/class-integrate-convertkit-wpforms.php:105
+msgid "No Form ID was specified."
+msgstr ""
+
+#: includes/class-integrate-convertkit-wpforms.php:324
+msgid "The API Key is required."
+msgstr ""
+
+#: includes/class-integrate-convertkit-wpforms.php:333
+msgid "The API Secret is required."
+msgstr ""
+
+#: includes/class-integrate-convertkit-wpforms.php:392
+msgid "Try ConvertKit for Free"
+msgstr ""
+
+#: includes/class-integrate-convertkit-wpforms.php:449
+#: includes/class-integrate-convertkit-wpforms.php:456
+msgid "No forms exist in ConvertKit"
+msgstr ""
+
+#: includes/class-integrate-convertkit-wpforms.php:522
+msgid "ConvertKit: Email"
+msgstr ""
+
+#: includes/class-integrate-convertkit-wpforms.php:528
+msgid "ConvertKit: First Name"
+msgstr ""
+
+#: includes/class-integrate-convertkit-wpforms.php:533
+msgid "ConvertKit: Tag"
+msgstr ""
+
+#. translators: ConvertKit Custom Field label
+#: includes/class-integrate-convertkit-wpforms.php:560
+msgid "ConvertKit: Custom Field: %s"
+msgstr ""
+
+#: includes/class-integrate-convertkit-wpforms.php:595
+msgid "No ConvertKit connections exist."
+msgstr ""
+
+#. translators: WPForms ConvertKit Account ID
+#: includes/class-integrate-convertkit-wpforms.php:603
+msgid "The ConvertKit connection with ID %s was unregistered."
+msgstr ""
+
+#: views/backend/settings-form-marketing-forms-dropdown.php:11
+msgid "ConvertKit Form"
+msgstr ""
+
+#: views/backend/settings-form-marketing.php:15
+#: views/backend/settings-integration.php:12
+msgid "API Key"
+msgstr ""
+
+#. translators: %1$s: Link to ConvertKit Account
+#: views/backend/settings-form-marketing.php:22
+#: views/backend/settings-form-marketing.php:39
+#: views/backend/settings-integration.php:19
+#: views/backend/settings-integration.php:36
+msgid "%1$s Required for proper plugin function."
+msgstr ""
+
+#: views/backend/settings-form-marketing.php:23
+#: views/backend/settings-integration.php:20
+msgid "Get your ConvertKit API Key."
+msgstr ""
+
+#: views/backend/settings-form-marketing.php:32
+#: views/backend/settings-integration.php:29
+msgid "API Secret"
+msgstr ""
+
+#: views/backend/settings-form-marketing.php:40
+#: views/backend/settings-integration.php:37
+msgid "Get your ConvertKit API Secret."
+msgstr ""
+
+#: views/backend/settings-form-marketing.php:49
+msgid "Connect to ConvertKit"
 msgstr ""


### PR DESCRIPTION
## Summary

Adds our internal scripts to generate:
- Localization .pot file, used by translators
- ACTIONS-FILTERS.md, used by developers

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)