### PR TITLE
Return Resources in correct order

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "1.3.0"
+        "convertkit/convertkit-wordpress-libraries": "1.3.1"
     },
     "require-dev": {
         "lucatume/wp-browser": "^3.0",

--- a/includes/class-integrate-convertkit-wpforms.php
+++ b/includes/class-integrate-convertkit-wpforms.php
@@ -456,6 +456,9 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 			return $this->error( __( 'No forms exist in ConvertKit', 'integrate-convertkit-wpforms' ) );
 		}
 
+		// Sort Forms in ascending order by name.
+		$forms = $this->sort_fields( $forms );
+
 		// Get the selected ConvertKit Form, if one was already defined.
 		$form_id = ! empty( $connection['list_id'] ) ? $connection['list_id'] : '';
 
@@ -552,6 +555,9 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 			return $provider_fields;
 		}
 
+		// Sort Custom Fields in ascending order by label.
+		$custom_fields = $this->sort_fields( $custom_fields, 'label' );
+
 		// Add Custom Fields to available field mappings.
 		foreach ( $custom_fields as $custom_field ) {
 			$provider_fields[] = array(
@@ -614,6 +620,30 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 
 		// Return instance.
 		return $this->api[ $account_id ];
+
+	}
+
+	/**
+	 * Returns the given array of fields (Forms, Tags or Custom Fields)
+	 * in alphabetical ascending order by label.
+	 *
+	 * @since   1.5.1
+	 *
+	 * @param   array  $resources   Resources.
+	 * @param   string $order_by    Order by array key (default: name).
+	 * @return  array               Sorted Resources by label
+	 */
+	private function sort_fields( $resources, $order_by = 'name' ) {
+
+		// Sort resources ascending by the label property.
+		uasort(
+			$resources,
+			function( $a, $b ) use ( $order_by ) {
+				return strcmp( $a[ $order_by ], $b[ $order_by ] );
+			}
+		);
+
+		return $resources;
 
 	}
 

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -34,4 +34,60 @@ class Plugin extends \Codeception\Module
 	{
 		$I->deactivateThirdPartyPlugin($I, 'integrate-convertkit-wpforms');
 	}
+
+	/**
+	 * Helper method to determine that the order of the Form resources in the given
+	 * select element are in the expected alphabetical order.
+	 *
+	 * @since   1.5.1
+	 *
+	 * @param   AcceptanceTester $I                 AcceptanceTester.
+	 * @param   string           $selectElement     <select> element.
+	 * @param   bool|array       $prependOptions    Option elements that should appear before the resources.
+	 */
+	public function checkSelectFormOptionOrder($I, $selectElement, $prependOptions = false)
+	{
+		// Define options.
+		$options = [
+			'AAA Test', // First item.
+			'WooCommerce Product Form', // Last item.
+		];
+
+		// Prepend options, such as 'Default' and 'None' to the options, if required.
+		if ( $prependOptions ) {
+			$options = array_merge( $prependOptions, $options );
+		}
+
+		// Check order.
+		$I->checkSelectOptionOrder($I, $selectElement, $options);
+	}
+
+	/**
+	 * Helper method to determine the order of <option> values for the given select element
+	 * and values.
+	 *
+	 * @since   1.5.1
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester.
+	 * @param   string           $selectElement <select> element.
+	 * @param   array            $values        <option> values.
+	 */
+	public function checkSelectOptionOrder($I, $selectElement, $values)
+	{
+		foreach ( $values as $i => $value ) {
+			// Define the applicable CSS selector.
+			if ( $i === 0 ) {
+				$nth = 'first-child';
+			} elseif ( $i + 1 === count( $values ) ) {
+				$nth = 'last-child';
+			} else {
+				$nth = 'nth-child(' . ( $i + 1 ) . ')';
+			}
+
+			$I->assertEquals(
+				$I->grabTextFrom('select' . $selectElement . ' option:' . $nth),
+				$value
+			);
+		}
+	}
 }

--- a/tests/_support/Helper/Acceptance/WPForms.php
+++ b/tests/_support/Helper/Acceptance/WPForms.php
@@ -257,6 +257,10 @@ class WPForms extends \Codeception\Module
 		$I->waitForElementVisible('div[data-connection_id="' . $connectionID . '"] .wpforms-provider-fields');
 
 		if ($formName) {
+			// Confirm that Forms are in ascending alphabetical order.
+			$I->checkSelectFormOptionOrder($I, '[name="providers[convertkit][' . $connectionID . '][list_id]"]');
+
+			// Select Form.
 			$I->selectOption('providers[convertkit][' . $connectionID . '][list_id]', $formName);
 
 			// Wait for field mappings to reload, as the ConvertKit Form has changed.
@@ -274,6 +278,16 @@ class WPForms extends \Codeception\Module
 
 		// Custom Fields.
 		if ($customFields) {
+			// Confirm that Custom Fields are listed in ascending alphabetical order in the table.
+			$I->assertEquals(
+				$I->grabTextFrom('.wpforms-provider-fields table tbody tr:nth-child(4) td:first-child'), // First Custom Field after Email, First Name, Tag.
+				'ConvertKit: Custom Field: Billing Address'
+			);
+			$I->assertEquals(
+				$I->grabTextFrom('.wpforms-provider-fields table tbody tr:last-child td:first-child'), // Last Custom Field.
+				'ConvertKit: Custom Field: Test'
+			);
+
 			foreach ($customFields as $customField => $customFieldValue) {
 				$I->selectOption('providers[convertkit][' . $connectionID . '][fields][custom_field_' . $customField . ']', $customFieldValue);
 			}


### PR DESCRIPTION
## Summary

Implements 1.3.1 of the WordPress Libraries, resolving [this issue](https://wordpress.org/support/topic/convertkit-tags-in-woocommerce-not-in-alphabetical-order/), to ensure that Forms and Custom Fields are returned in alphabetical order by name/label.

## Testing

- Added `checkSelect*Order()` helper functions to test that the order of `<select>` dropdown option are correct

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)