### PR TITLE
Fix User Agent Constants

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,8 @@ jobs:
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [
           'acceptance/forms',
-          'acceptance/general'
+          'acceptance/general',
+          'wpunit'
         ]
 
     # Steps to install, configure and run tests

--- a/includes/class-integrate-convertkit-wpforms-api.php
+++ b/includes/class-integrate-convertkit-wpforms-api.php
@@ -44,10 +44,10 @@ class Integrate_ConvertKit_WPForms_API extends ConvertKit_API {
 		$this->api_key        = $api_key;
 		$this->api_secret     = $api_secret;
 		$this->debug          = $debug;
-		$this->plugin_name    = ( defined( 'CKWC_PLUGIN_NAME' ) ? CKWC_PLUGIN_NAME : false );
-		$this->plugin_path    = ( defined( 'CKWC_PLUGIN_PATH' ) ? CKWC_PLUGIN_PATH : false );
-		$this->plugin_url     = ( defined( 'CKWC_PLUGIN_URL' ) ? CKWC_PLUGIN_URL : false );
-		$this->plugin_version = ( defined( 'CKWC_PLUGIN_VERSION' ) ? CKWC_PLUGIN_VERSION : false );
+		$this->plugin_name    = ( defined( 'INTEGRATE_CONVERTKIT_WPFORMS_NAME' ) ? INTEGRATE_CONVERTKIT_WPFORMS_NAME : false );
+		$this->plugin_path    = ( defined( 'INTEGRATE_CONVERTKIT_WPFORMS_PATH' ) ? INTEGRATE_CONVERTKIT_WPFORMS_PATH : false );
+		$this->plugin_url     = ( defined( 'INTEGRATE_CONVERTKIT_WPFORMS_URL' ) ? INTEGRATE_CONVERTKIT_WPFORMS_URL : false );
+		$this->plugin_version = ( defined( 'INTEGRATE_CONVERTKIT_WPFORMS_VERSION' ) ? INTEGRATE_CONVERTKIT_WPFORMS_VERSION : false );
 
 		// Setup logging class if the required parameters exist.
 		if ( $this->debug && $this->plugin_path !== false ) {

--- a/tests/wpunit.suite.yml
+++ b/tests/wpunit.suite.yml
@@ -19,4 +19,3 @@ modules:
             adminEmail: "%TEST_SITE_ADMIN_EMAIL%"
             title: "Test"
             plugins: ['convertkit-wpforms/integrate-convertkit-wpforms.php'] # Change to the repository Plugin that we're testing.
-            activatePlugins: ['convertkit-wpforms/integrate-convertkit-wpforms.php'] # Change to the repository Plugin that we're testing.

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Tests for the Integrate_ConvertKit_WPForms_API class.
+ *
+ * @since   1.5.1
+ */
+class APITest extends \Codeception\TestCase\WPTestCase
+{
+	/**
+	 * The testing implementation.
+	 *
+	 * @var \WpunitTester.
+	 */
+	protected $tester;
+
+	/**
+	 * Holds the ConvertKit API class.
+	 *
+	 * @since   1.5.1
+	 *
+	 * @var     Integrate_ConvertKit_WPForms_API
+	 */
+	private $api;
+
+	/**
+	 * Performs actions before each test.
+	 *
+	 * @since   1.5.1
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		// Activate Plugin, to include the Plugin's constants in tests.
+		activate_plugins('convertkit-wpforms/integrate-convertkit-wpforms.php');
+
+		// Include class from /includes to test, as they won't be loaded by the Plugin
+		// because WPForms is not active.
+		require_once 'includes/class-integrate-convertkit-wpforms-api.php';
+
+		// Initialize the classes we want to test.
+		$this->api = new Integrate_ConvertKit_WPForms_API( $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET'] );
+	}
+
+	/**
+	 * Performs actions after each test.
+	 *
+	 * @since   1.5.1
+	 */
+	public function tearDown(): void
+	{
+		// Destroy the classes we tested.
+		unset($this->api);
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that the User Agent string is in the expected format and
+	 * includes the Plugin's name and version number.
+	 *
+	 * @since   1.5.1
+	 */
+	public function testUserAgent()
+	{
+		// When an API call is made, inspect the user-agent argument.
+		add_filter(
+			'http_request_args',
+			function($args, $url) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
+				$this->assertStringContainsString(
+					INTEGRATE_CONVERTKIT_WPFORMS_NAME . '/' . INTEGRATE_CONVERTKIT_WPFORMS_VERSION,
+					$args['user-agent']
+				);
+				return $args;
+			},
+			10,
+			2
+		);
+
+		// Perform a request.
+		$result = $this->api->account();
+	}
+}


### PR DESCRIPTION
## Summary

Includes the Plugin's name and version number in the user-agent string when making API requests.

## Testing

- `APITest`: Unit test to confirm that the correct Plugin name and version number are included in the user-agent string when making API requests.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)