### PR TITLE
Review Request Notification

### DIFF
--- a/includes/class-integrate-convertkit-wpforms.php
+++ b/includes/class-integrate-convertkit-wpforms.php
@@ -24,6 +24,15 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 	public $api = array();
 
 	/**
+	 * Holds the review request class.
+	 *
+	 * @since   1.5.5
+	 *
+	 * @var     bool|ConvertKit_Review_Request
+	 */
+	private $review_request = false;
+
+	/**
 	 * Holds the ConvertKit registration URL.
 	 *
 	 * @since   1.5.0
@@ -54,6 +63,9 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 		$this->slug     = 'convertkit';
 		$this->priority = 14;
 		$this->icon     = INTEGRATE_CONVERTKIT_WPFORMS_URL . 'resources/backend/images/convertkit-logomark-red.svg';
+
+		// Initialize classes.
+		$this->review_request = new ConvertKit_Review_Request( 'ConvertKit for WPForms', 'integrate-convertkit-wpforms', INTEGRATE_CONVERTKIT_WPFORMS_PATH );
 
 		// Run update routine.
 		add_action( 'init', array( $this, 'update' ) );
@@ -304,6 +316,14 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 				);
 
 				return;
+			}
+
+			// Email subscribed to ConvertKit successfully; request a review.
+			// This can safely be called multiple times, as the review request
+			// class will ensure once a review request is dismissed by the user,
+			// it is never displayed again.
+			if ( $this->review_request ) {
+				$this->review_request->request_review();
 			}
 
 			// Log successful API response.
@@ -571,7 +591,16 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 			$id
 		);
 
+		// ConvertKit has been connected successfully; request a review.
+		// This can safely be called multiple times, as the review request
+		// class will ensure once a review request is dismissed by the user,
+		// it is never displayed again.
+		if ( $this->review_request ) {
+			$this->review_request->request_review();
+		}
+
 		return $id;
+
 	}
 
 	/**

--- a/integrate-convertkit-wpforms.php
+++ b/integrate-convertkit-wpforms.php
@@ -45,6 +45,9 @@ if ( ! class_exists( 'ConvertKit_API' ) ) {
 if ( ! class_exists( 'ConvertKit_Log' ) ) {
 	require_once INTEGRATE_CONVERTKIT_WPFORMS_PATH . '/vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-log.php';
 }
+if ( ! class_exists( 'ConvertKit_Review_Request' ) ) {
+	require_once INTEGRATE_CONVERTKIT_WPFORMS_PATH . '/vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-review-request.php';
+}
 
 /**
  * Load the class

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -90,4 +90,32 @@ class Plugin extends \Codeception\Module
 			);
 		}
 	}
+
+	/**
+	 * Helper method to determine that the options table has the expected values created
+	 * for a review request notification to be displayed in the WordPress Admin.
+	 *
+	 * @since   1.5.5
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester.
+	 */
+	public function reviewRequestExists($I)
+	{
+		$I->seeOptionInDatabase('integrate-convertkit-wpforms-review-request');
+		$I->dontSeeOptionInDatabase('integrate-convertkit-wpforms-review-dismissed');
+	}
+
+	/**
+	 * Helper method to determine that the options table does not have a review request
+	 * value specified.
+	 *
+	 * @since   1.5.5
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester.
+	 */
+	public function reviewRequestDoesNotExist($I)
+	{
+		$I->dontSeeOptionInDatabase('integrate-convertkit-wpforms-review-request');
+		$I->dontSeeOptionInDatabase('integrate-convertkit-wpforms-review-dismissed');
+	}
 }

--- a/tests/acceptance/forms/FormCest.php
+++ b/tests/acceptance/forms/FormCest.php
@@ -78,6 +78,9 @@ class FormCest
 		$I->waitForElementVisible('.wpforms-confirmation-scroll');
 		$I->seeInSource('Thanks for contacting us! We will be in touch with you shortly.');
 
+		// Check that a review request was created.
+		$I->reviewRequestExists($I);
+
 		// Check API to confirm subscriber was sent.
 		$I->apiCheckSubscriberExists($I, $emailAddress, $firstName);
 	}
@@ -149,6 +152,9 @@ class FormCest
 		// Confirm submission was successful.
 		$I->waitForElementVisible('.wpforms-confirmation-scroll');
 		$I->seeInSource('Thanks for contacting us! We will be in touch with you shortly.');
+
+		// Check that a review request was created.
+		$I->reviewRequestExists($I);
 
 		// Check API to confirm subscriber was sent.
 		$I->apiCheckSubscriberExists($I, $emailAddress, $firstName);
@@ -224,6 +230,9 @@ class FormCest
 		// Confirm submission was successful.
 		$I->waitForElementVisible('.wpforms-confirmation-scroll');
 		$I->seeInSource('Thanks for contacting us! We will be in touch with you shortly.');
+
+		// Check that a review request was created.
+		$I->reviewRequestExists($I);
 
 		// Check API to confirm subscriber was sent.
 		$I->apiCheckSubscriberExists($I, $emailAddress, $firstName);
@@ -302,6 +311,9 @@ class FormCest
 		$I->waitForElementVisible('.wpforms-confirmation-scroll');
 		$I->seeInSource('Thanks for contacting us! We will be in touch with you shortly.');
 
+		// Check that a review request was created.
+		$I->reviewRequestExists($I);
+
 		// Check API to confirm subscriber was sent.
 		$I->apiCheckSubscriberExists($I, $emailAddress, $firstName);
 
@@ -378,6 +390,9 @@ class FormCest
 		$I->waitForElementVisible('.wpforms-confirmation-scroll');
 		$I->seeInSource('Thanks for contacting us! We will be in touch with you shortly.');
 
+		// Check that a review request was created.
+		$I->reviewRequestExists($I);
+
 		// Check API to confirm subscriber was sent.
 		$I->apiCheckSubscriberExists($I, $emailAddress, $firstName);
 
@@ -452,6 +467,9 @@ class FormCest
 		// Confirm submission was successful.
 		$I->waitForElementVisible('.wpforms-confirmation-scroll');
 		$I->seeInSource('Thanks for contacting us! We will be in touch with you shortly.');
+
+		// Check that a review request was created.
+		$I->reviewRequestExists($I);
 
 		// Check API to confirm subscriber was sent.
 		$I->apiCheckSubscriberExists($I, $emailAddress, $firstName);
@@ -530,6 +548,9 @@ class FormCest
 		$I->waitForElementVisible('.wpforms-confirmation-scroll');
 		$I->seeInSource('Thanks for contacting us! We will be in touch with you shortly.');
 
+		// Check that a review request was created.
+		$I->reviewRequestExists($I);
+
 		// Check API to confirm subscriber was sent.
 		$I->apiCheckSubscriberExists($I, $emailAddress, $firstName);
 
@@ -604,6 +625,9 @@ class FormCest
 		// Confirm submission was successful.
 		$I->waitForElementVisible('.wpforms-confirmation-scroll');
 		$I->seeInSource('Thanks for contacting us! We will be in touch with you shortly.');
+
+		// Check that a review request was created.
+		$I->reviewRequestExists($I);
 
 		// Check API to confirm subscriber was sent and data mapped to fields correctly.
 		$I->apiCheckSubscriberExists($I, $emailAddress, $firstName, $customFields);

--- a/tests/acceptance/general/ReviewRequestCest.php
+++ b/tests/acceptance/general/ReviewRequestCest.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Tests the ConvertKit Review Notification.
+ *
+ * @since   1.5.5
+ */
+class ReviewRequestCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   1.5.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		$I->activateConvertKitPlugin($I);
+		$I->activateThirdPartyPlugin($I, 'wpforms-lite');
+	}
+
+	/**
+	 * Test that adding a ConvertKit account to the ConvertKit integration sections
+	 * sets a review request in the options table when valid API credentials are
+	 * specified.
+	 *
+	 * @since   1.5.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testReviewRequestOnSaveValidAPICredentials(AcceptanceTester $I)
+	{
+		// Load WPForms > Settings > Integrations.
+		$I->amOnAdminPage('admin.php?page=wpforms-settings&view=integrations');
+
+		// Expand ConvertKit integration section.
+		$I->click('#wpforms-integration-convertkit');
+
+		// Click Add New Account button.
+		$I->click('#wpforms-integration-convertkit a[data-provider="convertkit"]');
+
+		// Fill fields.
+		$I->waitForElementVisible('.wpforms-settings-provider-accounts-connect input[name="api_key"]');
+		$I->fillField('api_key', $_ENV['CONVERTKIT_API_KEY']);
+		$I->fillField('api_secret', $_ENV['CONVERTKIT_API_SECRET']);
+
+		// Click Connect to ConvertKit button.
+		$I->click('Connect to ConvertKit');
+
+		// Confirm that the 'Connected' element is visible.
+		$I->waitForElementVisible('#wpforms-integration-convertkit .wpforms-settings-provider-info .connected-indicator');
+		$I->see('Connected on:');
+
+		// Check that a review request was created.
+		$I->reviewRequestExists($I);
+	}
+
+	/**
+	 * Test that no review request is set in the options table when the Plugin's
+	 * Settings are saved with no Forms specified in the Settings.
+	 *
+	 * @since   1.5.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testReviewRequestOnSaveInvalidAPICredentials(AcceptanceTester $I)
+	{
+		// Load WPForms > Settings > Integrations.
+		$I->amOnAdminPage('admin.php?page=wpforms-settings&view=integrations');
+
+		// Expand ConvertKit integration section.
+		$I->click('#wpforms-integration-convertkit');
+
+		// Click Add New Account button.
+		$I->click('#wpforms-integration-convertkit a[data-provider="convertkit"]');
+
+		// Fill fields.
+		$I->waitForElementVisible('.wpforms-settings-provider-accounts-connect input[name="api_key"]');
+		$I->fillField('api_key', 'invalidApiKey');
+		$I->fillField('api_secret', 'invalidApiSecret');
+
+		// Click Connect to ConvertKit button.
+		$I->click('Connect to ConvertKit');
+
+		// Confirm the expected error message displays.
+		$I->waitForElementVisible('.jconfirm-box');
+		$I->see('Could not authenticate with the provider');
+		$I->see('Authorization Failed: API Key not valid');
+
+		// Check that no review request was created.
+		$I->reviewRequestDoesNotExist($I);
+	}
+
+	/**
+	 * Test that the review request is displayed when the options table entries
+	 * have the required values to display the review request notification.
+	 *
+	 * @since   1.5.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testReviewRequestNotificationDisplaysAndDismisses(AcceptanceTester $I)
+	{
+		// Set review request option with a timestamp in the past, to emulate
+		// the Plugin having set this a few days ago.
+		$I->haveOptionInDatabase('integrate-convertkit-wpforms-review-request', time() - 3600 );
+
+		// Navigate to a screen in the WordPress Administration.
+		$I->amOnAdminPage('index.php');
+
+		// Confirm the review displays.
+		$I->seeElementInDOM('div.review-integrate-convertkit-wpforms');
+
+		// Confirm links are correct.
+		$I->seeInSource('<a href="https://wordpress.org/support/plugin/integrate-convertkit-wpforms/reviews/?filter=5#new-post" class="button button-primary" rel="noopener" target="_blank">');
+		$I->seeInSource('<a href="https://convertkit.com/support" class="button" rel="noopener" target="_blank">');
+
+		// Dismiss the review request.
+		$I->click('div.review-integrate-convertkit-wpforms button.notice-dismiss');
+
+		// Navigate to a screen in the WordPress Administration.
+		$I->amOnAdminPage('index.php');
+
+		// Confirm the review notification no longer displays.
+		$I->dontSeeElementInDOM('div.review-integrate-convertkit-wpforms');
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   1.5.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+
+		// We don't use deactivateThirdPartyPlugin(), as this checks for PHP warnings/errors.
+		// WPForms throws a 502 bad gateway on deactivation, which is outside of our control
+		// and would result in the test not completing.
+		$I->amOnPluginsPage();
+		$I->deactivatePlugin('wpforms-lite');
+	}
+}

--- a/views/backend/review/notice.php
+++ b/views/backend/review/notice.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Notification output for a review request.
+ *
+ * @package ConvertKit_WPForms
+ * @author ConvertKit
+ */
+
+?>
+
+<div class="notice notice-info is-dismissible review-<?php echo esc_attr( $this->plugin_slug ); ?>">
+	<p>
+		<?php
+		echo esc_html(
+			sprintf(
+				/* translators: Plugin Name */
+				__( 'We\'d be super grateful if you could spread the word about %s and give it a 5 star rating on WordPress?', 'integrate-convertkit-wpforms' ),
+				$this->plugin_name
+			)
+		);
+		?>
+	</p>
+	<p>
+		<a href="<?php echo esc_attr( $this->get_review_url() ); ?>" class="button button-primary" rel="noopener" target="_blank">
+			<?php esc_html_e( 'Yes, leave review', 'integrate-convertkit-wpforms' ); ?>
+		</a>
+		<a href="<?php echo esc_attr( $this->get_support_url() ); ?>" class="button" rel="noopener" target="_blank">
+			<?php
+			echo esc_html(
+				sprintf(
+					/* translators: Plugin Name */
+					__( 'No, I\'m having issues with %s', 'integrate-convertkit-wpforms' ),
+					$this->plugin_name
+				)
+			);
+			?>
+		</a>
+	</p>
+
+	<script type="text/javascript">
+		jQuery( document ).ready( function( $ ) {
+			// Dismiss Review Notification.
+			$( 'div.review-<?php echo esc_attr( $this->plugin_slug ); ?>' ).on( 'click', 'a, button.notice-dismiss', function( e ) {
+
+				// Do request
+				$.post( 
+					ajaxurl, 
+					{
+						action: '<?php echo esc_attr( str_replace( '-', '_', $this->plugin_slug ) ); ?>_dismiss_review',
+					},
+					function( response ) {
+					}
+				);
+
+				// Hide notice
+				$( 'div.review-<?php echo esc_attr( $this->plugin_slug ); ?>' ).hide();
+
+			} );
+		} );
+	</script>
+</div>
+


### PR DESCRIPTION
## Summary

As implemented for ConvertKit's other WordPress Plugins, adds a notification in the WordPress Administration interface requesting the user leave a 5 star review on [wordpress.org](https://wordpress.org/support/plugin/integrate-convertkit-wpforms/reviews/), to assist with the Plugin's ranking on search results within WordPress.

![Screenshot 2023-04-04 at 14 24 20](https://user-images.githubusercontent.com/1462305/229807609-b504a2e2-36f0-49fd-b256-ba077559aff3.png)

Clicking either button or the close button hides the notification for life; no other WordPress Administrator will see it.

Clicking `Yes, Leave Review` hides the notification, and opens a new browser tab at https://wordpress.org/support/plugin/integrate-convertkit-wpforms/reviews/?filter=5#new-post
Clicking `No, I'm having issues with ConvertKit for WPForms` opens a new browser tab at https://convertkit.com/support

This notification will only display when the following conditions are all met:
- The user is in the WordPress Administration interface,
- The user is an Administrator (lower roles, such as Editor or Author will not see this notification),
- An action is performed (either adding ConvertKit API credentials in WPForms, or a form submission sending data to ConvertKit)
- It has been at least 3 days since an action was performed (this is to avoid bombarding the user with notifications so soon after using the Plugin)
- The notification has not previously been dismissed.
- The site is not a Multisite installation (Multisite allows multiple sites within a single WordPress instance; showing notifications on every site would therefore be frustrating for the site owner who most likely controls all sites in the single WordPress instance).

The conditions are deliberately restrictive, to avoid aggressively and persistently asking the user for a review, and to prevent us adding to the potential large number of notifications that various Themes and Plugins add to WordPress' Administration interface: https://wptavern.com/new-dobby-plugin-captures-and-hides-unwanted-wordpress-admin-notices

## Testing

- `FormCest`: Updated existing tests to include a check that the expected notification value in the options table is set when a form submission is successfully sent to ConvertKit
- `ReviewRequestCest`: Tests to ensure the notification displays, or does not display, depending on the actions performed. Also tests that the notification never displays once dismissed.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)