### PR TITLE
Update WordPress Libraries to 1.3.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "1.3.4"
+        "convertkit/convertkit-wordpress-libraries": "1.3.5"
     },
     "require-dev": {
         "lucatume/wp-browser": "^3.0",

--- a/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
+++ b/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
@@ -68,6 +68,9 @@ class ThirdPartyPlugin extends \Codeception\Module
 		// Deactivate the Plugin.
 		$I->deactivatePlugin($name);
 
+		// Wait for notice to display.
+		$I->waitForElementVisible('div.updated');
+
 		// Check that the Plugin deactivated successfully.
 		$I->seePluginDeactivated($name);
 	}


### PR DESCRIPTION
## Summary

Uses [1.3.5](https://github.com/ConvertKit/convertkit-wordpress-libraries/releases/tag/1.3.5) of our WordPress Libraries.

Fixes the test `deactivateThirdPartyPlugin` helper function, which would falsely assert a plugin had not always been deactivated, despite the resulting screenshot showing it had:

![IntegrationsCest testAddIntegrationWithValidAPICredentials fail](https://github.com/ConvertKit/convertkit-wpforms/assets/1462305/e7e6b2bb-f0d2-4c26-a96f-afd72cf0bad0)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)