### PR TITLE
Fix API Key wrongly being saved to the API Secret

### DIFF
--- a/includes/class-integrate-convertkit-wpforms.php
+++ b/includes/class-integrate-convertkit-wpforms.php
@@ -584,7 +584,7 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 			$this->slug,
 			array(
 				'api_key'    => sanitize_text_field( $settings['api_key'] ),
-				'api_secret' => sanitize_text_field( $settings['api_key'] ),
+				'api_secret' => sanitize_text_field( $settings['api_secret'] ),
 				'label'      => $result['name'] . ' (' . $result['primary_email_address'] . ')',
 				'date'       => time(),
 			),

--- a/tests/_support/Helper/Acceptance/WPForms.php
+++ b/tests/_support/Helper/Acceptance/WPForms.php
@@ -34,6 +34,28 @@ class WPForms extends \Codeception\Module
 	}
 
 	/**
+	 * Helper method to check that a ConvertKit integration is registered as a provider with the given
+	 * API Key and Secret
+	 *
+	 * @since   1.5.8
+	 *
+	 * @param   AcceptanceTester $I         AcceptanceTester.
+	 * @param   string           $apiKey    API Key.
+	 * @param   string           $apiSecret API Secret.
+	 */
+	public function checkWPFormsIntegrationExists($I, $apiKey, $apiSecret)
+	{
+		$providers = $I->grabOptionFromDatabase('wpforms_providers');
+		foreach ($providers['convertkit'] as $provider) {
+			if ($provider['api_key'] === $apiKey && $provider['api_secret'] === $apiSecret) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Creates a WPForms Form with ConvertKit Settings, as if it were created
 	 * in 1.4.1 or older.
 	 *

--- a/tests/acceptance/general/IntegrationsCest.php
+++ b/tests/acceptance/general/IntegrationsCest.php
@@ -50,6 +50,10 @@ class IntegrationsCest
 		$I->waitForElementVisible('#wpforms-integration-convertkit .wpforms-settings-provider-info .connected-indicator');
 		$I->see('Connected on:');
 
+		// Confirm that the API Key and Secret were saved to the database.
+		// This sanity checks that we didn't accidentally save the API Key to the API Secret field as we did in 1.5.7 and lower.
+		$I->assertTrue($I->checkWPFormsIntegrationExists($I, $_ENV['CONVERTKIT_API_KEY'], $_ENV['CONVERTKIT_API_SECRET']));
+
 		// Confirm that the connection can be disconnected.
 		$I->click('Disconnect');
 


### PR DESCRIPTION
## Summary

Fixes an issue when an API Secret defined at WPForms > Settings > Integrations > ConvertKit does not reflect the API Secret entered when saving.

## Testing

- `testAddIntegrationWithValidAPICredentials`: Added helper method to check that the API Key and Secret are saved to the correct fields in the database.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)