### PR TITLE
Change Creator Network Recommendations settings key

### DIFF
--- a/includes/class-integrate-convertkit-wpforms-creator-network-recommendations.php
+++ b/includes/class-integrate-convertkit-wpforms-creator-network-recommendations.php
@@ -40,7 +40,7 @@ class Integrate_ConvertKit_WPForms_Creator_Network_Recommendations {
 	 *
 	 * @var     string
 	 */
-	private $creator_network_recommendations_script_key = 'convertkit_creator_network_recommendations_script';
+	private $creator_network_recommendations_script_key = 'convertkit_wpforms_creator_network_recommendations';
 
 	/**
 	 * Holds the URL to the WPForms Integrations screen.

--- a/tests/_support/Helper/Acceptance/WPForms.php
+++ b/tests/_support/Helper/Acceptance/WPForms.php
@@ -436,7 +436,7 @@ class WPForms extends \Codeception\Module
 		}
 
 		// Enable Creator Network Recommendations.
-		$I->click('label[for="wpforms-panel-field-settings-convertkit_creator_network_recommendations_script"]');
+		$I->click('label[for="wpforms-panel-field-settings-convertkit_wpforms_creator_network_recommendations"]');
 
 		// Click Save.
 		$I->click('#wpforms-save');


### PR DESCRIPTION
## Summary

Prevents a potential conflict with the main ConvertKit Plugin, which uses `convertkit_creator_network_recommendations`.  A site with both this Plugin and the ConvertKit Plugin installed would otherwise share the setting, which might be undesirable if the user has two different ConvertKit accounts (unlikely, but never impossible).

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)