### PR TITLE
Update incorrect link in readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -16,7 +16,7 @@ Create ConvertKit signup forms using WPForms
 
 This Plugin integrates WPForms with ConvertKit, allowing form submissions to be automatically sent to your ConvertKit account.
 
-Full plugin documentation is located [here](https://help.convertkit.com/en/articles/2502569-gravity-forms-integration).
+Full plugin documentation is located [here](https://cultivatewp.com/our-plugins/integrate-convertkit-wpforms/).
 
 == Installation ==
 


### PR DESCRIPTION
## Summary

Link to instructions at https://cultivatewp.com/our-plugins/integrate-convertkit-wpforms/ instead of the Gravity Forms docs, fixing #33 

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)