### PR TITLE
Add deploy readme.txt GitHub Action

### DIFF
--- a/.github/workflows/deploy-readme.yml
+++ b/.github/workflows/deploy-readme.yml
@@ -1,0 +1,18 @@
+name: Deploy readme.txt to WordPress.org
+on:
+  push:
+    branches:
+    - main
+jobs:
+  trunk:
+    name: Push to trunk
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: WordPress.org plugin asset/readme update
+      uses: 10up/action-wordpress-plugin-asset-update@stable
+      env:
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        SLUG: integrate-convertkit-wpforms
+        IGNORE_OTHER_FILES: true

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: nathanbarry, convertkit, billerickson
 Donate link: https://convertkit.com
 Tags: form, wpforms, convertkit, email, marketing
 Requires at least: 5.0
-Tested up to: 6.2.2
+Tested up to: 6.3
 Stable tag: 1.5.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
## Summary

Adds a [GitHub Action](https://github.com/10up/action-wordpress-plugin-asset-update) to only deploy the readme.txt file if changed in the `main` branch.

This allows changes to be made to the readme file (typically the `Tested up to` WordPress version number), without needing to deploy an entire version update to the Plugin.

Screenshots of this action tested on another Plugin, where the `Tested up to` value was changed to WordPress 6.3:

![Screenshot 2023-08-14 at 17 43 42](https://github.com/ConvertKit/convertkit-wpforms/assets/1462305/4e90509a-c798-414f-9b05-1922eb16c057)

![Screenshot_2023-08-14_at_17_43_48](https://github.com/ConvertKit/convertkit-wpforms/assets/1462305/3074d0b7-51ef-4807-bf02-07b4aeb4af95)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)