### PR TITLE
Upgrade to WordPress Coding Standards v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,7 @@
         "codeception/module-filesystem": "^1.0",                                   
         "codeception/module-cli": "^1.0",                                          
         "codeception/util-universalframework": "^1.0",
-        "squizlabs/php_codesniffer": "3.*",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-        "wp-coding-standards/wpcs": "*",
+        "wp-coding-standards/wpcs": "^3.0.0",
         "phpstan/phpstan": "^1.7",
         "szepeviktor/phpstan-wordpress": "^1.0"
     },

--- a/includes/class-integrate-convertkit-wpforms-creator-network-recommendations.php
+++ b/includes/class-integrate-convertkit-wpforms-creator-network-recommendations.php
@@ -198,7 +198,7 @@ class Integrate_ConvertKit_WPForms_Creator_Network_Recommendations {
 		if ( ! $link ) {
 			echo esc_html( $text );
 		} else {
-			echo sprintf(
+			printf(
 				'%s <a href="%s" target="_blank">%s</a>',
 				esc_html( $text ),
 				esc_url( $link ),

--- a/includes/class-integrate-convertkit-wpforms.php
+++ b/includes/class-integrate-convertkit-wpforms.php
@@ -734,7 +734,7 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 		// Sort resources ascending by the label property.
 		uasort(
 			$resources,
-			function( $a, $b ) use ( $order_by ) {
+			function ( $a, $b ) use ( $order_by ) {
 				return strcmp( $a[ $order_by ], $b[ $order_by ] );
 			}
 		);

--- a/phpcs.tests.xml
+++ b/phpcs.tests.xml
@@ -22,26 +22,28 @@
         <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceAfterOpenParenthesis" />
         <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.ExtraSpaceAfterCloseParenthesis" />
         <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterOpen" />
+        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingBeforeClose" />
         <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceBeforeCloseParenthesis" />
         <exclude name="Generic.Classes.OpeningBraceSameLine.BraceOnNewLine" />
         <exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie.BraceOnNewLine" />
         <exclude name="PEAR.Functions.FunctionCallSignature.SpaceBeforeOpenBracket" />
         <exclude name="PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket" />
         <exclude name="PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket" />
+        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction" />
 
         <!-- _before() and _passed() must use underscores in Codeception -->
         <exclude name="PSR2.Methods.MethodDeclaration.Underscore" />
 
         <!-- Permit [] instead of array() -->
-        <exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
-        
+        <exclude name="Universal.Arrays.DisallowShortArraySyntax.Found" />
+
         <!-- We might use some datetime functions for tests -->
         <exclude name="WordPress.DateTime.RestrictedFunctions" />
 
         <!-- Handles false positives where Coding Standards thinks we did something wrong when we're just checking for e.g. a stylesheet -->
         <exclude name="WordPress.WP.EnqueuedResources" />
         <exclude name="WordPress.PHP.DiscouragedPHPFunctions" />
-        <exclude name="WordPress.WP.CapitalPDangit.Misspelled" />
+        <exclude name="WordPress.WP.CapitalPDangit.MisspelledInText" />
     </rule>
 
     <!-- Check that code is documented to WordPress Standards. -->

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,7 +3,6 @@
 	<description>WordPress Coding Standards for Plugins</description>
 
 	<!-- Exclude some directories. -->
-	<exclude-pattern>/.scripts/*</exclude-pattern>
 	<exclude-pattern>/.wordpress-org/*</exclude-pattern>
 	<exclude-pattern>/tests/*</exclude-pattern>
 	<exclude-pattern>/vendor/*</exclude-pattern>
@@ -30,6 +29,8 @@
 		<exclude name="WordPress.Security.EscapeOutput"/>
 		-->
 		<exclude name="WordPress.PHP.YodaConditions" />
+		<exclude name="PSR2.Methods.FunctionClosingBrace.SpacingBeforeClose" />
+		<exclude name="PSR2.Classes.ClassDeclaration.CloseBraceAfterBody" />
 	</rule>
 
 	<!-- Check that code is documented to WordPress Standards. -->


### PR DESCRIPTION
## Summary

Applies changes per the upgrade guide [here](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Upgrade-Guide-to-WordPressCS-3.0.0-for-Developers-of-external-standards), to support `3.0.0` of the WordPress Coding Standards rulesets, released August 21st.

This covers:
- Using `printf` instead of `echo sprintf`
- Spacing for anonymous functions
- Renaming some exclusion rules as they have been renamed in WordPress Coding Standards `3.0.0`

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)