### PR TITLE
Use Secure Log in WordPress Libraries

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -2,6 +2,7 @@
 /.github
 /.scripts
 /.wordpress-org
+/log
 /tests
 /vendor/autoload.php
 /vendor/composer

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .env.testing
 codeception.yml
 composer.lock
+log
 log.txt
 phpstan.neon
 tests/_output

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "dev-secure-log-file"
+        "convertkit/convertkit-wordpress-libraries": "1.4.2"
     },
     "require-dev": {
         "lucatume/wp-browser": "<3.5",

--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,10 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "1.4.1"
+        "convertkit/convertkit-wordpress-libraries": "dev-secure-log-file"
     },
     "require-dev": {
-        "lucatume/wp-browser": "^3.0",
+        "lucatume/wp-browser": "<3.5",
         "codeception/module-asserts": "^1.3",                                      
         "codeception/module-phpbrowser": "^1.0",                                   
         "codeception/module-webdriver": "^1.0",                                    
@@ -41,6 +41,7 @@
             "composer.json",
             "composer.lock",
             "Gruntfile.js",
+            "log",
             "log.txt",
             "package.json",
             "package-lock.json",


### PR DESCRIPTION
## Summary

Uses a more secure log file method, as added in our [WordPress Libraries](https://github.com/ConvertKit/convertkit-wordpress-libraries/pull/34).

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)