### PR TITLE
v4 API: Support per-account resource caching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "dev-v4-api-refresh-token-action-data"
+        "convertkit/convertkit-wordpress-libraries": "dev-v4-api"
     },
     "require-dev": {
         "lucatume/wp-browser": "<3.5",

--- a/includes/class-integrate-convertkit-wpforms-resource.php
+++ b/includes/class-integrate-convertkit-wpforms-resource.php
@@ -20,11 +20,18 @@ class Integrate_ConvertKit_WPForms_Resource extends ConvertKit_Resource_V4 {
 	 * @since   1.7.0
 	 *
 	 * @param   Integrate_ConvertKit_WPForms_API $api_instance   API Instance.
+	 * @param   string                           $account_id     WPForms Account ID.
 	 */
-	public function __construct( $api_instance ) {
+	public function __construct( $api_instance, $account_id = '' ) {
 
 		// Initialize the API using the supplied Integrate_ConvertKit_WPForms_API instance.
 		$this->api = $api_instance;
+
+		// Append the account ID to the settings key, so that multiple connections can each
+		// have their own cached resources specific to that account.
+		if ( $account_id ) {
+			$this->settings_name .= '_' . $account_id;
+		}
 
 		// Call parent initialization function.
 		parent::init();

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -176,4 +176,20 @@ class Plugin extends \Codeception\Module
 		$I->seeOptionInDatabase('integrate_convertkit_wpforms_tags_' . $accountID);
 		$I->seeOptionInDatabase('integrate_convertkit_wpforms_custom_fields_' . $accountID);
 	}
+
+	/**
+	 * Checks that the resources are not cached for the given
+	 * WPForms Account ID.
+	 *
+	 * @since   1.7.0
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester.
+	 * @param   string           $accountID     Account ID.
+	 */
+	public function dontSeeCachedResourcesInDatabase($I, $accountID)
+	{
+		$I->dontSeeOptionInDatabase('integrate_convertkit_wpforms_forms_' . $accountID);
+		$I->dontSeeOptionInDatabase('integrate_convertkit_wpforms_tags_' . $accountID);
+		$I->dontSeeOptionInDatabase('integrate_convertkit_wpforms_custom_fields_' . $accountID);
+	}
 }

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -160,4 +160,20 @@ class Plugin extends \Codeception\Module
 		// Confirm the recommendations script was not loaded.
 		$I->dontSeeInSource('recommendations.js');
 	}
+
+	/**
+	 * Checks that the resources are cached with the correct key for the given
+	 * WPForms Account ID.
+	 *
+	 * @since   1.7.0
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester.
+	 * @param   string           $accountID     Account ID.
+	 */
+	public function seeCachedResourcesInDatabase($I, $accountID)
+	{
+		$I->seeOptionInDatabase('integrate_convertkit_wpforms_forms_' . $accountID);
+		$I->seeOptionInDatabase('integrate_convertkit_wpforms_tags_' . $accountID);
+		$I->seeOptionInDatabase('integrate_convertkit_wpforms_custom_fields_' . $accountID);
+	}
 }

--- a/tests/_support/Helper/Acceptance/WPForms.php
+++ b/tests/_support/Helper/Acceptance/WPForms.php
@@ -547,4 +547,32 @@ class WPForms extends \Codeception\Module
 			]
 		);
 	}
+
+	/**
+	 * Disconnects the given account ID via the UI in WPForms > Settings > Integrations.
+	 *
+	 * @since   1.7.0
+	 *
+	 * @param   AcceptanceTester $I         AcceptanceTester.
+	 * @param   string           $accountID Account ID.
+	 */
+	public function disconnectAccount($I, $accountID)
+	{
+		// Login as admin.
+		$I->loginAsAdmin();
+
+		// Click Disconnect.
+		$I->amOnAdminPage('admin.php?page=wpforms-settings&view=integrations');
+		$I->click('#wpforms-integration-convertkit');
+		$I->waitForElementVisible('#wpforms-integration-convertkit .wpforms-settings-provider-accounts-list span.remove a[data-key="' . $accountID . '"]');
+		$I->click('#wpforms-integration-convertkit .wpforms-settings-provider-accounts-list span.remove a[data-key="' . $accountID . '"]');
+
+		// Confirm that we want to disconnect.
+		$I->waitForElementVisible('.jconfirm-box');
+		$I->click('.jconfirm-box button.btn-confirm');
+
+		// Confirm connection is no longer listed.
+		$I->wait(5);
+		$I->dontSeeElementInDOM('a[data-key="' . $accountID . '"]');
+	}
 }

--- a/tests/acceptance/forms/FormCest.php
+++ b/tests/acceptance/forms/FormCest.php
@@ -32,7 +32,7 @@ class FormCest
 	public function testCreateForm(AcceptanceTester $I)
 	{
 		// Define connection with valid API credentials.
-		$I->setupWPFormsIntegration($I);
+		$accountID = $I->setupWPFormsIntegration($I);
 
 		// Create Form.
 		$wpFormsID = $I->createWPFormsForm($I);
@@ -45,6 +45,9 @@ class FormCest
 			'Name (First)',
 			'Email'
 		);
+
+		// Check that the resources are cached with the correct key.
+		$I->seeCachedResourcesInDatabase($I, $accountID);
 
 		// Create a Page with the WPForms shortcode as its content.
 		$pageID = $I->createPageWithWPFormsShortcode($I, $wpFormsID);
@@ -102,7 +105,7 @@ class FormCest
 	public function testCreateFormWithTagID(AcceptanceTester $I)
 	{
 		// Define connection with valid API credentials.
-		$I->setupWPFormsIntegration($I);
+		$accountID = $I->setupWPFormsIntegration($I);
 
 		// Create Form.
 		$wpFormsID = $I->createWPFormsForm(
@@ -122,6 +125,9 @@ class FormCest
 			false, // Custom Fields.
 			'Tag ID' // Name of Tag Field in WPForms.
 		);
+
+		// Check that the resources are cached with the correct key.
+		$I->seeCachedResourcesInDatabase($I, $accountID);
 
 		// Create a Page with the WPForms shortcode as its content.
 		$pageID = $I->createPageWithWPFormsShortcode($I, $wpFormsID);
@@ -183,7 +189,7 @@ class FormCest
 	public function testCreateFormWithInvalidTagID(AcceptanceTester $I)
 	{
 		// Define connection with valid API credentials.
-		$I->setupWPFormsIntegration($I);
+		$accountID = $I->setupWPFormsIntegration($I);
 
 		// Create Form.
 		$wpFormsID = $I->createWPFormsForm(
@@ -203,6 +209,9 @@ class FormCest
 			false, // Custom Fields.
 			'Tag ID' // Name of Tag Field in WPForms.
 		);
+
+		// Check that the resources are cached with the correct key.
+		$I->seeCachedResourcesInDatabase($I, $accountID);
 
 		// Create a Page with the WPForms shortcode as its content.
 		$pageID = $I->createPageWithWPFormsShortcode($I, $wpFormsID);
@@ -264,7 +273,7 @@ class FormCest
 	public function testCreateFormWithTagIDs(AcceptanceTester $I)
 	{
 		// Define connection with valid API credentials.
-		$I->setupWPFormsIntegration($I);
+		$accountID = $I->setupWPFormsIntegration($I);
 
 		// Create Form.
 		$wpFormsID = $I->createWPFormsForm(
@@ -285,6 +294,9 @@ class FormCest
 			false, // Custom Fields.
 			'Tag ID' // Name of Tag Field in WPForms.
 		);
+
+		// Check that the resources are cached with the correct key.
+		$I->seeCachedResourcesInDatabase($I, $accountID);
 
 		// Create a Page with the WPForms shortcode as its content.
 		$pageID = $I->createPageWithWPFormsShortcode($I, $wpFormsID);
@@ -348,7 +360,7 @@ class FormCest
 	public function testCreateFormWithTagName(AcceptanceTester $I)
 	{
 		// Define connection with valid API credentials.
-		$I->setupWPFormsIntegration($I);
+		$accountID = $I->setupWPFormsIntegration($I);
 
 		// Create Form.
 		$wpFormsID = $I->createWPFormsForm(
@@ -368,6 +380,9 @@ class FormCest
 			false, // Custom Fields.
 			'Tag ID' // Name of Tag Field in WPForms.
 		);
+
+		// Check that the resources are cached with the correct key.
+		$I->seeCachedResourcesInDatabase($I, $accountID);
 
 		// Create a Page with the WPForms shortcode as its content.
 		$pageID = $I->createPageWithWPFormsShortcode($I, $wpFormsID);
@@ -429,7 +444,7 @@ class FormCest
 	public function testCreateFormWithInvalidTagName(AcceptanceTester $I)
 	{
 		// Define connection with valid API credentials.
-		$I->setupWPFormsIntegration($I);
+		$accountID = $I->setupWPFormsIntegration($I);
 
 		// Create Form.
 		$wpFormsID = $I->createWPFormsForm(
@@ -449,6 +464,9 @@ class FormCest
 			false, // Custom Fields.
 			'Tag ID' // Name of Tag Field in WPForms.
 		);
+
+		// Check that the resources are cached with the correct key.
+		$I->seeCachedResourcesInDatabase($I, $accountID);
 
 		// Create a Page with the WPForms shortcode as its content.
 		$pageID = $I->createPageWithWPFormsShortcode($I, $wpFormsID);
@@ -510,7 +528,7 @@ class FormCest
 	public function testCreateFormWithTagNames(AcceptanceTester $I)
 	{
 		// Define connection with valid API credentials.
-		$I->setupWPFormsIntegration($I);
+		$accountID = $I->setupWPFormsIntegration($I);
 
 		// Create Form.
 		$wpFormsID = $I->createWPFormsForm(
@@ -531,6 +549,9 @@ class FormCest
 			false, // Custom Fields.
 			'Tag ID' // Name of Tag Field in WPForms.
 		);
+
+		// Check that the resources are cached with the correct key.
+		$I->seeCachedResourcesInDatabase($I, $accountID);
 
 		// Create a Page with the WPForms shortcode as its content.
 		$pageID = $I->createPageWithWPFormsShortcode($I, $wpFormsID);
@@ -594,7 +615,7 @@ class FormCest
 	public function testCreateFormWithCustomField(AcceptanceTester $I)
 	{
 		// Define connection with valid API credentials.
-		$I->setupWPFormsIntegration($I);
+		$accountID = $I->setupWPFormsIntegration($I);
 
 		// Create Form.
 		$wpFormsID = $I->createWPFormsForm($I);
@@ -610,6 +631,9 @@ class FormCest
 				$_ENV['CONVERTKIT_API_CUSTOM_FIELD_NAME'] => 'Comment or Message', // ConvertKit Custom Field --> WPForms Field Name mapping.
 			)
 		);
+
+		// Check that the resources are cached with the correct key.
+		$I->seeCachedResourcesInDatabase($I, $accountID);
 
 		// Create a Page with the WPForms shortcode as its content.
 		$pageID = $I->createPageWithWPFormsShortcode($I, $wpFormsID);

--- a/tests/acceptance/forms/FormCest.php
+++ b/tests/acceptance/forms/FormCest.php
@@ -89,6 +89,12 @@ class FormCest
 
 		// Check that a review request was created.
 		$I->reviewRequestExists($I);
+
+		// Disconnect the account.
+		$I->disconnectAccount($I, $accountID);
+
+		// Check that the resources are no longer cached under the given account ID.
+		$I->dontSeeCachedResourcesInDatabase($I, $accountID);
 	}
 
 	/**
@@ -173,6 +179,12 @@ class FormCest
 
 		// Check that a review request was created.
 		$I->reviewRequestExists($I);
+
+		// Disconnect the account.
+		$I->disconnectAccount($I, $accountID);
+
+		// Check that the resources are no longer cached under the given account ID.
+		$I->dontSeeCachedResourcesInDatabase($I, $accountID);
 	}
 
 	/**
@@ -257,6 +269,12 @@ class FormCest
 
 		// Check that a review request was created.
 		$I->reviewRequestExists($I);
+
+		// Disconnect the account.
+		$I->disconnectAccount($I, $accountID);
+
+		// Check that the resources are no longer cached under the given account ID.
+		$I->dontSeeCachedResourcesInDatabase($I, $accountID);
 	}
 
 	/**
@@ -344,6 +362,12 @@ class FormCest
 
 		// Check that a review request was created.
 		$I->reviewRequestExists($I);
+
+		// Disconnect the account.
+		$I->disconnectAccount($I, $accountID);
+
+		// Check that the resources are no longer cached under the given account ID.
+		$I->dontSeeCachedResourcesInDatabase($I, $accountID);
 	}
 
 	/**
@@ -428,6 +452,12 @@ class FormCest
 
 		// Check that a review request was created.
 		$I->reviewRequestExists($I);
+
+		// Disconnect the account.
+		$I->disconnectAccount($I, $accountID);
+
+		// Check that the resources are no longer cached under the given account ID.
+		$I->dontSeeCachedResourcesInDatabase($I, $accountID);
 	}
 
 	/**
@@ -512,6 +542,12 @@ class FormCest
 
 		// Check that a review request was created.
 		$I->reviewRequestExists($I);
+
+		// Disconnect the account.
+		$I->disconnectAccount($I, $accountID);
+
+		// Check that the resources are no longer cached under the given account ID.
+		$I->dontSeeCachedResourcesInDatabase($I, $accountID);
 	}
 
 	/**
@@ -599,6 +635,12 @@ class FormCest
 
 		// Check that a review request was created.
 		$I->reviewRequestExists($I);
+
+		// Disconnect the account.
+		$I->disconnectAccount($I, $accountID);
+
+		// Check that the resources are no longer cached under the given account ID.
+		$I->dontSeeCachedResourcesInDatabase($I, $accountID);
 	}
 
 	/**
@@ -679,6 +721,12 @@ class FormCest
 
 		// Check that a review request was created.
 		$I->reviewRequestExists($I);
+
+		// Disconnect the account.
+		$I->disconnectAccount($I, $accountID);
+
+		// Check that the resources are no longer cached under the given account ID.
+		$I->dontSeeCachedResourcesInDatabase($I, $accountID);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

WPForms has the concept of multiple `accounts` (or connections) for a given provider:
<img width="1041" alt="Screenshot 2024-06-21 at 21 29 02" src="https://github.com/ConvertKit/convertkit-wpforms/assets/1462305/e9eed641-e278-4e06-9d97-0ffbbab05493">

This PR adds support for caching resources (forms, tags, custom fields) against the specific account ID being used.

## Testing

- `FormCest`: Added checks to confirm resources are cached against an account specific ID, and caches are deleted when an account is disconnected via the WPForms UI.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)