### PR TITLE
Prefix Form ID in Settings

### DIFF
--- a/includes/class-integrate-convertkit-wpforms-setup.php
+++ b/includes/class-integrate-convertkit-wpforms-setup.php
@@ -127,7 +127,7 @@ class Integrate_ConvertKit_WPForms_Setup {
 			if ( ! $form_configuration_changed ) {
 				continue;
 			}
-			
+
 			// Save data back to the form.
 			$form_handler->update( $form->ID, $data );
 		}

--- a/includes/class-integrate-convertkit-wpforms-setup.php
+++ b/includes/class-integrate-convertkit-wpforms-setup.php
@@ -45,8 +45,92 @@ class Integrate_ConvertKit_WPForms_Setup {
 			$this->maybe_get_access_tokens_by_api_keys_and_secrets();
 		}
 
+		/**
+		 * 1.7.2: Migrate Form settings.
+		 */
+		if ( ! $current_version || version_compare( $current_version, '1.7.2', '<' ) ) {
+			$this->migrate_form_settings();
+		}
+
 		// Update the installed version number in the options table.
 		update_option( 'integrate_convertkit_wpforms_version', INTEGRATE_CONVERTKIT_WPFORMS_VERSION );
+
+	}
+
+	/**
+	 * 1.7.2: Prefix any connection form settings with `form:`, now that
+	 * the Plugin supports adding a subscriber to a Form, Tag or Sequence.
+	 *
+	 * @since   1.7.2
+	 */
+	private function migrate_form_settings() {
+
+		// Bail if the WPForms handler class isn't available.
+		if ( ! class_exists( 'WPForms_Form_Handler' ) ) {
+			return;
+		}
+
+		// Get all forms.
+		$form_handler = new WPForms_Form_Handler();
+		$forms        = $form_handler->get();
+
+		// Bail if no WPForms Forms exist.
+		if ( ! is_array( $forms ) ) {
+			return;
+		}
+		if ( count( $forms ) === 0 ) {
+			return;
+		}
+
+		// Iterate through forms.
+		foreach ( $forms as $form ) {
+			// Flag to denote no changes made to the form.
+			$form_configuration_changed = false;
+
+			// Decode settings into array.
+			$data = wpforms_decode( $form->post_content );
+
+			// Skip if no ConvertKit provider configured for this form.
+			if ( ! array_key_exists( 'providers', $data ) ) {
+				continue;
+			}
+			if ( ! array_key_exists( 'convertkit', $data['providers'] ) ) {
+				continue;
+			}
+
+			// Iterate through ConvertKit providers.
+			foreach ( $data['providers']['convertkit'] as $connection_id => $connection ) {
+				// Skip if no list_id specified.
+				if ( ! array_key_exists( 'list_id', $connection ) ) {
+					continue;
+				}
+
+				// Skip values that are blank i.e. no ConvertKit Form ID specified.
+				if ( empty( $connection['list_id'] ) ) {
+					continue;
+				}
+
+				// Skip values that are non-numeric i.e. the `form:` prefix was already added.
+				// This should never happen as this routine runs once, but this is a sanity check.
+				if ( ! is_numeric( $connection['list_id'] ) ) {
+					continue;
+				}
+
+				// Prefix the ConvertKit Form ID with `form:`.
+				$data['providers']['convertkit'][ $connection_id ]['list_id'] = 'form:' . $connection['list_id'];
+
+				// Flag that this form needs to be saved.
+				$form_configuration_changed = true;
+			}
+
+			// If no changes made to the form configuration, move to the next form.
+			if ( ! $form_configuration_changed ) {
+				continue;
+			}
+			
+			// Save data back to the form.
+			$form_handler->update( $form->ID, $data );
+		}
 
 	}
 

--- a/includes/class-integrate-convertkit-wpforms.php
+++ b/includes/class-integrate-convertkit-wpforms.php
@@ -479,48 +479,18 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 		// Fetch Forms.
 		// We use refresh() to ensure we get the latest data, as we're in the admin interface
 		// and need to populate the select dropdown.
-		$resource_forms = new Integrate_ConvertKit_WPForms_Resource_Forms( $api, $connection['account_id'] );
-		$forms          = $resource_forms->refresh();
-
-		// Bail if an error occured.
-		if ( is_wp_error( $forms ) ) {
-			// Log the error.
-			wpforms_log(
-				'ConvertKit',
-				$forms->get_error_message(),
-				array(
-					'type' => array( 'provider', 'error' ),
-				)
-			);
-
-			// Return error message.
-			return $this->error( $forms->get_error_message() );
-		}
-
-		// Bail if no Forms exist.
-		if ( empty( $forms ) ) {
-			// Log the error.
-			wpforms_log(
-				'ConvertKit',
-				__( 'No forms exist in ConvertKit', 'integrate-convertkit-wpforms' ),
-				array(
-					'type' => array( 'provider', 'error' ),
-				)
-			);
-
-			// Return error message.
-			return $this->error( __( 'No forms exist in ConvertKit', 'integrate-convertkit-wpforms' ) );
-		}
+		$forms = new Integrate_ConvertKit_WPForms_Resource_Forms( $api, $connection['account_id'] );
+		$forms->refresh();
 
 		// Fetch Tags.
 		// We use refresh() to ensure we get the latest data, as we're in the admin interface.
 		// When the frontend then queries the resource class, it'll get the most up to date
 		// tag data without needing to make an API call.
-		$resource_tags = new Integrate_ConvertKit_WPForms_Resource_Tags( $api, $connection['account_id'] );
-		$resource_tags->refresh();
+		$tags = new Integrate_ConvertKit_WPForms_Resource_Tags( $api, $connection['account_id'] );
+		$tags->refresh();
 
-		// Get the selected ConvertKit Form, if one was already defined.
-		$form_id = ! empty( $connection['list_id'] ) ? $connection['list_id'] : '';
+		// Get the selected ConvertKit subscribe setting, if one was already defined.
+		$value = ! empty( $connection['list_id'] ) ? $connection['list_id'] : '';
 
 		// Output <select> dropdown.
 		ob_start();

--- a/tests/_support/Helper/Acceptance/WPForms.php
+++ b/tests/_support/Helper/Acceptance/WPForms.php
@@ -372,8 +372,14 @@ class WPForms extends \Codeception\Module
 		$I->waitForElementVisible('div[data-connection_id="' . $connectionID . '"] .wpforms-provider-fields');
 
 		if ($formName) {
-			// Confirm that Forms are in ascending alphabetical order.
-			$I->checkSelectFormOptionOrder($I, '[name="providers[convertkit][' . $connectionID . '][list_id]"]');
+			// Confirm that Forms are in ascending alphabetical order, with 'Subscribe' as the first choice.
+			$I->checkSelectFormOptionOrder(
+				$I,
+				'[name="providers[convertkit][' . $connectionID . '][list_id]"]',
+				[
+					'Subscribe',
+				]
+			);
 
 			// Select Form.
 			$I->selectOption('providers[convertkit][' . $connectionID . '][list_id]', $formName);

--- a/tests/_support/Helper/Acceptance/WPForms.php
+++ b/tests/_support/Helper/Acceptance/WPForms.php
@@ -372,15 +372,6 @@ class WPForms extends \Codeception\Module
 		$I->waitForElementVisible('div[data-connection_id="' . $connectionID . '"] .wpforms-provider-fields');
 
 		if ($formName) {
-			// Confirm that Forms are in ascending alphabetical order, with 'Subscribe' as the first choice.
-			$I->checkSelectFormOptionOrder(
-				$I,
-				'[name="providers[convertkit][' . $connectionID . '][list_id]"]',
-				[
-					'Subscribe',
-				]
-			);
-
 			// Select Form.
 			$I->selectOption('providers[convertkit][' . $connectionID . '][list_id]', $formName);
 

--- a/tests/acceptance/forms/FormCest.php
+++ b/tests/acceptance/forms/FormCest.php
@@ -29,7 +29,7 @@ class FormCest
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testCreateForm(AcceptanceTester $I)
+	public function testCreateFormToConvertKitFormMapping(AcceptanceTester $I)
 	{
 		// Define connection with valid API credentials.
 		$accountID = $I->setupWPFormsIntegration($I);
@@ -42,6 +42,84 @@ class FormCest
 			$I,
 			$wpFormsID,
 			$_ENV['CONVERTKIT_API_FORM_NAME'],
+			'Name (First)',
+			'Email'
+		);
+
+		// Check that the resources are cached with the correct key.
+		$I->seeCachedResourcesInDatabase($I, $accountID);
+
+		// Create a Page with the WPForms shortcode as its content.
+		$pageID = $I->createPageWithWPFormsShortcode($I, $wpFormsID);
+
+		// Define Name and Email Address for this Test.
+		$firstName    = 'First';
+		$lastName     = 'Last';
+		$emailAddress = $I->generateEmailAddress();
+
+		// Logout as the WordPress Administrator.
+		$I->logOut();
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Complete Form Fields.
+		$I->fillField('input.wpforms-field-name-first', $firstName);
+		$I->fillField('input.wpforms-field-name-last', $lastName);
+		$I->fillField('.wpforms-field-email input[type=email]', $emailAddress);
+
+		// Submit Form.
+		$I->click('Submit');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm submission was successful.
+		$I->waitForElementVisible('.wpforms-confirmation-scroll');
+		$I->seeInSource('Thanks for contacting us! We will be in touch with you shortly.');
+
+		// Check that a review request was created.
+		$I->reviewRequestExists($I);
+
+		// Check API to confirm subscriber was sent.
+		$I->apiCheckSubscriberExists($I, $emailAddress, $firstName);
+
+		// Check that a review request was created.
+		$I->reviewRequestExists($I);
+
+		// Disconnect the account.
+		$I->disconnectAccount($I, $accountID);
+
+		// Check that the resources are no longer cached under the given account ID.
+		$I->dontSeeCachedResourcesInDatabase($I, $accountID);
+	}
+
+	/**
+	 * Test that the Plugin works when:
+	 * - Creating a WPForms Form,
+	 * - Adding a valid ConvertKit Connection,
+	 * - Submitting the Form on the frontend web site results in the email address subscribing only (with no form/tag/sequence).
+	 *
+	 * @since   1.7.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testCreateFormSubscribeOnly(AcceptanceTester $I)
+	{
+		// Define connection with valid API credentials.
+		$accountID = $I->setupWPFormsIntegration($I);
+
+		// Create Form.
+		$wpFormsID = $I->createWPFormsForm($I);
+
+		// Configure ConvertKit on Form.
+		$I->configureConvertKitSettingsOnForm(
+			$I,
+			$wpFormsID,
+			'Subscribe',
 			'Name (First)',
 			'Email'
 		);

--- a/tests/acceptance/general/UpgradePathsCest.php
+++ b/tests/acceptance/general/UpgradePathsCest.php
@@ -107,8 +107,8 @@ class UpgradePathsCest
 			],
 
 			// Other required settings.
-			'field_id' => '0',
-			'settings' => [
+			'field_id'  => '0',
+			'settings'  => [
 				'store_spam_entries' => '0',
 			],
 		];
@@ -134,9 +134,11 @@ class UpgradePathsCest
 		$settings['providers']['convertkit']['connection_123']['list_id'] = 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'];
 
 		// Check settings structure has been updated for the Form.
-		$I->seePostInDatabase([
-			'ID' => $formID,
-			'post_content' => json_encode( $settings ), // phpcs:ignore WordPress.WP.AlternativeFunctions
-		]);
+		$I->seePostInDatabase(
+			[
+				'ID'           => $formID,
+				'post_content' => json_encode( $settings ), // phpcs:ignore WordPress.WP.AlternativeFunctions
+			]
+		);
 	}
 }

--- a/views/backend/settings-form-marketing-forms-dropdown.php
+++ b/views/backend/settings-form-marketing-forms-dropdown.php
@@ -9,13 +9,32 @@
 ?>
 <div class="wpforms-provider-lists wpforms-connection-block">
 	<h4><?php esc_html_e( 'ConvertKit Form', 'integrate-convertkit-wpforms' ); ?></h4>
+
 	<select name="providers[<?php echo esc_attr( $this->slug ); ?>][<?php echo esc_attr( $connection_id ); ?>][list_id]" size="1">
-		<?php
-		foreach ( $forms as $form ) {
-			?>
-			<option value="<?php echo esc_attr( $form['id'] ); ?>"<?php selected( $form['id'], $form_id ); ?>><?php echo esc_attr( $form['name'] ); ?></option>
+		<option <?php selected( 'subscribe', $value ); ?> value="subscribe" data-preserve-on-refresh="1">
+			<?php esc_html_e( 'Subscribe', 'convertkit' ); ?>
+		</option>
+
+		<optgroup label="<?php esc_attr_e( 'Forms', 'convertkit' ); ?>" id="convertkit-forms" data-option-value-prefix="form:">
 			<?php
-		}
-		?>
+			if ( $forms->exist() ) {
+				foreach ( $forms->get() as $form ) {
+					printf(
+						'<option value="%s"%s>%s [%s]</option>',
+						esc_attr( 'form:' . $form['id'] ),
+						selected( 'form:' . $form['id'], $value, false ),
+						esc_attr( $form['name'] ),
+						( ! empty( $form['format'] ) ? esc_attr( $form['format'] ) : 'inline' )
+					);
+				}
+			}
+			?>
+		</optgroup>
 	</select>
+
+	<p class="note">
+		<code><?php esc_html_e( 'Subscribe', 'integrate-convertkit-wpforms' ); ?></code>: <?php esc_html_e( 'Subscribes the email address to ConvertKit', 'integrate-convertkit-wpforms' ); ?>
+		<br />
+		<code><?php esc_html_e( 'Form', 'integrate-convertkit-wpforms' ); ?></code>: <?php esc_html_e( 'Susbcribes the email address to ConvertKit, and adds the subscriber to the ConvertKit Form', 'integrate-convertkit-wpforms' ); ?>
+	</p>
 </div>

--- a/views/backend/settings-form-marketing-forms-dropdown.php
+++ b/views/backend/settings-form-marketing-forms-dropdown.php
@@ -12,10 +12,10 @@
 
 	<select name="providers[<?php echo esc_attr( $this->slug ); ?>][<?php echo esc_attr( $connection_id ); ?>][list_id]" size="1">
 		<option <?php selected( 'subscribe', $value ); ?> value="subscribe" data-preserve-on-refresh="1">
-			<?php esc_html_e( 'Subscribe', 'convertkit' ); ?>
+			<?php esc_html_e( 'Subscribe', 'integrate-convertkit-wpforms' ); ?>
 		</option>
 
-		<optgroup label="<?php esc_attr_e( 'Forms', 'convertkit' ); ?>" id="convertkit-forms" data-option-value-prefix="form:">
+		<optgroup label="<?php esc_attr_e( 'Forms', 'integrate-convertkit-wpforms' ); ?>" id="convertkit-wpforms-forms" data-option-value-prefix="form:">
 			<?php
 			if ( $forms->exist() ) {
 				foreach ( $forms->get() as $form ) {


### PR DESCRIPTION
## Summary

Similar to the [WooCommerce Plugin](https://github.com/ConvertKit/convertkit-woocommerce/blob/main/views/backend/subscription-dropdown-field.php#L42), prefixes the settings in Contact Form 7 with `form:`, so we know the IDs specified relate to ConvertKit Forms.

This allows adding Tags and Sequences to the dropdown options to assign to the subscriber in a later PR.

## Testing

- `testCreateFormToConvertKitFormMapping`: Renamed test to reflect this checks subscribing works when defining a ConvertKit Form ID
- `testCreateFormSubscribeOnly`: Test that subscribing works when the `Subscribe` option is selected, instead of a ConvertKit Form
- `testFormSettingsPrefixAddedToSettingsOnUpgrade`: Test that settings are migrated to the `form:id` format on Plugin update/upgrade.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)