### PR TITLE
Add Tag to Subscriber

### DIFF
--- a/includes/class-integrate-convertkit-wpforms.php
+++ b/includes/class-integrate-convertkit-wpforms.php
@@ -318,12 +318,28 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 				// Cast ID.
 				$resource_id = absint( $resource_id );
 
-				// For Legacy Forms, a different endpoint is used.
-				if ( $resource_forms->is_legacy( $resource_id ) ) {
-					$response = $api->add_subscriber_to_legacy_form( $resource_id, $subscriber['subscriber']['id'] );
-				} else {
-					// Add subscriber to form.
-					$response = $api->add_subscriber_to_form( $resource_id, $subscriber['subscriber']['id'] );
+				// Add the subscriber to the resource type (form, tag etc).
+				switch ( $resource_type ) {
+
+					/**
+					 * Form
+					 */
+					case 'form':
+						// For Legacy Forms, a different endpoint is used.
+						if ( $resource_forms->is_legacy( $resource_id ) ) {
+							$response = $api->add_subscriber_to_legacy_form( $resource_id, $subscriber['subscriber']['id'] );
+						} else {
+							// Add subscriber to form.
+							$response = $api->add_subscriber_to_form( $resource_id, $subscriber['subscriber']['id'] );
+						}
+
+					/**
+					 * Tag
+					 */
+					case 'tag':
+						// Add subscriber to tag.
+						$response = $api->tag_subscriber( $resource_id, $subscriber['subscriber']['id'] );
+
 				}
 
 				// If the API response is an error, log it as an error.
@@ -506,9 +522,8 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 		$forms->refresh();
 
 		// Fetch Tags.
-		// We use refresh() to ensure we get the latest data, as we're in the admin interface.
-		// When the frontend then queries the resource class, it'll get the most up to date
-		// tag data without needing to make an API call.
+		// We use refresh() to ensure we get the latest data, as we're in the admin interface
+		// and need to populate the select dropdown.
 		$tags = new Integrate_ConvertKit_WPForms_Resource_Tags( $api, $connection['account_id'] );
 		$tags->refresh();
 

--- a/includes/class-integrate-convertkit-wpforms.php
+++ b/includes/class-integrate-convertkit-wpforms.php
@@ -332,6 +332,7 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 							// Add subscriber to form.
 							$response = $api->add_subscriber_to_form( $resource_id, $subscriber['subscriber']['id'] );
 						}
+						break;
 
 					/**
 					 * Tag
@@ -339,6 +340,21 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 					case 'tag':
 						// Add subscriber to tag.
 						$response = $api->tag_subscriber( $resource_id, $subscriber['subscriber']['id'] );
+						break;
+
+					/**
+					 * Unsupported resource type
+					 */
+					default:
+						$response = new WP_Error(
+							'integrate_convertkit_wpforms_process_entry_resource_invalid',
+							sprintf(
+								/* translators: Resource type */
+								esc_html__( 'The resource type %s is unsupported.', 'integrate-convertkit-wpforms' ),
+								$resource_type
+							)
+						);
+						break;
 
 				}
 

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -49,6 +49,7 @@ class ConvertKitAPI extends \Codeception\Module
 	 * @param   string           $emailAddress  Email Address.
 	 * @param   bool|string      $firstName     First Name.
 	 * @param   bool|array       $customFields  Custom Fields.
+	 * @return  int                             Subscriber ID.
 	 */
 	public function apiCheckSubscriberExists($I, $emailAddress, $firstName = false, $customFields = false)
 	{
@@ -80,6 +81,9 @@ class ConvertKitAPI extends \Codeception\Module
 				$I->assertEquals($results['subscribers'][0]['fields'][ $customField ], $customFieldValue);
 			}
 		}
+
+		// Return subscriber ID.
+		return $results['subscribers'][0]['id'];
 	}
 
 	/**
@@ -110,19 +114,16 @@ class ConvertKitAPI extends \Codeception\Module
 	}
 
 	/**
-	 * Checks if the given email address has the given tag.
+	 * Check the given subscriber ID has been assigned to the given tag ID.
 	 *
 	 * @since   1.4.0
 	 *
-	 * @param   AcceptanceTester $I              AcceptanceTester.
-	 * @param   string           $emailAddress   Email Address.
-	 * @param   string           $tagID          Tag ID.
+	 * @param   AcceptanceTester $I             AcceptanceTester.
+	 * @param   int              $subscriberID  Subscriber ID.
+	 * @param   int              $tagID         Tag ID.
 	 */
-	public function apiCheckSubscriberHasTag($I, $emailAddress, $tagID)
+	public function apiCheckSubscriberHasTag($I, $subscriberID, $tagID)
 	{
-		// Get subscriber ID by email.
-		$subscriberID = $this->apiGetSubscriberIDByEmail($emailAddress);
-
 		// Get subscriber tags.
 		$subscriberTags = $this->apiGetSubscriberTags($subscriberID);
 
@@ -139,77 +140,20 @@ class ConvertKitAPI extends \Codeception\Module
 	}
 
 	/**
-	 * Checks if the given email address does not have the given tag.
-	 *
-	 * @since   1.4.0
-	 *
-	 * @param   AcceptanceTester $I              AcceptanceTester.
-	 * @param   string           $emailAddress   Email Address.
-	 * @param   string           $tagID          Tag ID.
-	 */
-	public function apiCheckSubscriberDoesNotHaveTag($I, $emailAddress, $tagID)
-	{
-		// Get subscriber ID by email.
-		$subscriberID = $this->apiGetSubscriberIDByEmail($emailAddress);
-
-		// Get subscriber tags.
-		$subscriberTags = $this->apiGetSubscriberTags($subscriberID);
-
-		$subscriberTagged = false;
-		foreach ($subscriberTags as $tag) {
-			if ( (int) $tag['id'] === (int) $tagID) {
-				$subscriberTagged = true;
-				break;
-			}
-		}
-
-		// Check that the Subscriber is not tagged.
-		$I->assertFalse($subscriberTagged);
-	}
-
-	/**
 	 * Checks if the given email address has no tags in ConvertKit.
 	 *
 	 * @since   1.5.4
 	 *
 	 * @param   AcceptanceTester $I              AcceptanceTester.
-	 * @param   string           $emailAddress   Email Address.
+	 * @param   int              $subscriberID   Subscriber ID.
 	 */
-	public function apiCheckSubscriberHasNoTags($I, $emailAddress)
+	public function apiCheckSubscriberHasNoTags($I, $subscriberID)
 	{
-		// Get subscriber ID by email.
-		$subscriberID = $this->apiGetSubscriberIDByEmail($emailAddress);
-
 		// Get subscriber tags.
 		$subscriberTags = $this->apiGetSubscriberTags($subscriberID);
 
 		// Confirm no tags exist.
 		$I->assertCount(0, $subscriberTags);
-	}
-
-	/**
-	 * Returns the subscriber ID for the given email address from the API.
-	 *
-	 * @since   1.5.4
-	 *
-	 * @param   string $emailAddress  Subscriber Email Address.
-	 * @return  array
-	 */
-	public function apiGetSubscriberIDByEmail($emailAddress)
-	{
-		$subscriber = $this->apiRequest(
-			'subscribers',
-			'GET',
-			[
-				'email_address'       => $emailAddress,
-				'include_total_count' => true,
-
-				// Some test email addresses might bounce, so we want to check all subscriber states.
-				'status'              => 'all',
-			]
-		);
-
-		return $subscriber['subscribers'][0]['id'];
 	}
 
 	/**

--- a/tests/_support/Helper/Acceptance/WPForms.php
+++ b/tests/_support/Helper/Acceptance/WPForms.php
@@ -369,14 +369,14 @@ class WPForms extends \Codeception\Module
 		$connectionID = $I->grabAttributeFrom('.wpforms-provider-connections .wpforms-provider-connection', 'data-connection_id');
 
 		// Specify field values.
-		$I->waitForElementVisible('div[data-connection_id="' . $connectionID . '"] .wpforms-provider-fields');
+		$I->waitForElementVisible('div[data-connection_id="' . $connectionID . '"] .wpforms-provider-fields', 30);
 
 		if ($formName) {
 			// Select Form.
 			$I->selectOption('providers[convertkit][' . $connectionID . '][list_id]', $formName);
 
 			// Wait for field mappings to reload, as the ConvertKit Form has changed.
-			$I->waitForElementVisible('div[data-connection_id="' . $connectionID . '"] .wpforms-provider-fields');
+			$I->waitForElementVisible('div[data-connection_id="' . $connectionID . '"] .wpforms-provider-fields', 30);
 		}
 		if ($emailField) {
 			$I->selectOption('providers[convertkit][' . $connectionID . '][fields][email]', $emailField);

--- a/tests/acceptance/forms/FormBackwardCompatCest.php
+++ b/tests/acceptance/forms/FormBackwardCompatCest.php
@@ -91,10 +91,10 @@ class FormBackwardCompatCest
 		$I->seeInSource('Thanks for contacting us! We will be in touch with you shortly.');
 
 		// Check API to confirm subscriber was sent.
-		$I->apiCheckSubscriberExists($I, $emailAddress);
+		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check API to confirm subscriber has Tag set.
-		$I->apiCheckSubscriberHasTag($I, $emailAddress, $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
 	}
 
 	/**

--- a/tests/acceptance/forms/FormCest.php
+++ b/tests/acceptance/forms/FormCest.php
@@ -101,6 +101,88 @@ class FormCest
 	 * Test that the Plugin works when:
 	 * - Creating a WPForms Form,
 	 * - Adding a valid ConvertKit Connection,
+	 * - Submitting the Form on the frontend web site results in the email address subscribing to the ConvertKit Tag.
+	 *
+	 * @since   1.7.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testCreateFormToConvertKitTagMapping(AcceptanceTester $I)
+	{
+		// Define connection with valid API credentials.
+		$accountID = $I->setupWPFormsIntegration($I);
+
+		// Create Form.
+		$wpFormsID = $I->createWPFormsForm($I);
+
+		// Configure ConvertKit on Form.
+		$I->configureConvertKitSettingsOnForm(
+			$I,
+			$wpFormsID,
+			$_ENV['CONVERTKIT_API_TAG_NAME'],
+			'Name (First)',
+			'Email'
+		);
+
+		// Check that the resources are cached with the correct key.
+		$I->seeCachedResourcesInDatabase($I, $accountID);
+
+		// Create a Page with the WPForms shortcode as its content.
+		$pageID = $I->createPageWithWPFormsShortcode($I, $wpFormsID);
+
+		// Define Name and Email Address for this Test.
+		$firstName    = 'First';
+		$lastName     = 'Last';
+		$emailAddress = $I->generateEmailAddress();
+
+		// Logout as the WordPress Administrator.
+		$I->logOut();
+
+		// Load the Page on the frontend site.
+		$I->amOnPage('/?p=' . $pageID);
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Complete Form Fields.
+		$I->fillField('input.wpforms-field-name-first', $firstName);
+		$I->fillField('input.wpforms-field-name-last', $lastName);
+		$I->fillField('.wpforms-field-email input[type=email]', $emailAddress);
+
+		// Submit Form.
+		$I->click('Submit');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm submission was successful.
+		$I->waitForElementVisible('.wpforms-confirmation-scroll');
+		$I->seeInSource('Thanks for contacting us! We will be in touch with you shortly.');
+
+		// Check that a review request was created.
+		$I->reviewRequestExists($I);
+
+		// Check API to confirm subscriber was sent.
+		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress, $firstName);
+
+		// Check API to confirm subscriber has Tag set.
+		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
+
+		// Check that a review request was created.
+		$I->reviewRequestExists($I);
+
+		// Disconnect the account.
+		$I->disconnectAccount($I, $accountID);
+
+		// Check that the resources are no longer cached under the given account ID.
+		$I->dontSeeCachedResourcesInDatabase($I, $accountID);
+	}
+
+
+	/**
+	 * Test that the Plugin works when:
+	 * - Creating a WPForms Form,
+	 * - Adding a valid ConvertKit Connection,
 	 * - Submitting the Form on the frontend web site results in the email address subscribing only (with no form/tag/sequence).
 	 *
 	 * @since   1.7.2
@@ -250,10 +332,10 @@ class FormCest
 		$I->reviewRequestExists($I);
 
 		// Check API to confirm subscriber was sent.
-		$I->apiCheckSubscriberExists($I, $emailAddress, $firstName);
+		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress, $firstName);
 
 		// Check API to confirm subscriber has Tag set.
-		$I->apiCheckSubscriberHasTag($I, $emailAddress, $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
 
 		// Check that a review request was created.
 		$I->reviewRequestExists($I);
@@ -340,10 +422,10 @@ class FormCest
 		$I->reviewRequestExists($I);
 
 		// Check API to confirm subscriber was sent.
-		$I->apiCheckSubscriberExists($I, $emailAddress, $firstName);
+		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress, $firstName);
 
 		// Confirm no tags were added to the subscriber, as the submitted tag doesn't exist in ConvertKit.
-		$I->apiCheckSubscriberHasNoTags($I, $emailAddress);
+		$I->apiCheckSubscriberHasNoTags($I, $subscriberID);
 
 		// Check that a review request was created.
 		$I->reviewRequestExists($I);
@@ -432,11 +514,11 @@ class FormCest
 		$I->reviewRequestExists($I);
 
 		// Check API to confirm subscriber was sent.
-		$I->apiCheckSubscriberExists($I, $emailAddress, $firstName);
+		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress, $firstName);
 
 		// Check API to confirm subscriber has Tags set.
-		$I->apiCheckSubscriberHasTag($I, $emailAddress, $_ENV['CONVERTKIT_API_TAG_ID']);
-		$I->apiCheckSubscriberHasTag($I, $emailAddress, $_ENV['CONVERTKIT_API_TAG_ID_2']);
+		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID_2']);
 
 		// Check that a review request was created.
 		$I->reviewRequestExists($I);
@@ -523,10 +605,10 @@ class FormCest
 		$I->reviewRequestExists($I);
 
 		// Check API to confirm subscriber was sent.
-		$I->apiCheckSubscriberExists($I, $emailAddress, $firstName);
+		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress, $firstName);
 
 		// Check API to confirm subscriber has Tag set.
-		$I->apiCheckSubscriberHasTag($I, $emailAddress, $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
 
 		// Check that a review request was created.
 		$I->reviewRequestExists($I);
@@ -613,10 +695,10 @@ class FormCest
 		$I->reviewRequestExists($I);
 
 		// Check API to confirm subscriber was sent.
-		$I->apiCheckSubscriberExists($I, $emailAddress, $firstName);
+		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress, $firstName);
 
 		// Confirm no tags were added to the subscriber, as the submitted tag doesn't exist in ConvertKit.
-		$I->apiCheckSubscriberHasNoTags($I, $emailAddress);
+		$I->apiCheckSubscriberHasNoTags($I, $subscriberID);
 
 		// Check that a review request was created.
 		$I->reviewRequestExists($I);
@@ -705,11 +787,11 @@ class FormCest
 		$I->reviewRequestExists($I);
 
 		// Check API to confirm subscriber was sent.
-		$I->apiCheckSubscriberExists($I, $emailAddress, $firstName);
+		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress, $firstName);
 
 		// Check API to confirm subscriber has Tags set.
-		$I->apiCheckSubscriberHasTag($I, $emailAddress, $_ENV['CONVERTKIT_API_TAG_ID']);
-		$I->apiCheckSubscriberHasTag($I, $emailAddress, $_ENV['CONVERTKIT_API_TAG_ID_2']);
+		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID_2']);
 
 		// Check that a review request was created.
 		$I->reviewRequestExists($I);

--- a/views/backend/settings-form-marketing-forms-dropdown.php
+++ b/views/backend/settings-form-marketing-forms-dropdown.php
@@ -30,11 +30,28 @@
 			}
 			?>
 		</optgroup>
+
+		<optgroup label="<?php esc_attr_e( 'Tags', 'convertkit' ); ?>" id="convertkit-wpforms-tags" data-option-value-prefix="tag:">
+			<?php
+			if ( $tags->exist() ) {
+				foreach ( $tags->get() as $convertkit_tag ) {
+					printf(
+						'<option value="%s"%s>%s</option>',
+						esc_attr( 'tag:' . $convertkit_tag['id'] ),
+						selected( 'tag:' . $convertkit_tag['id'], $value, false ),
+						esc_attr( $convertkit_tag['name'] )
+					);
+				}
+			}
+			?>
+		</optgroup>
 	</select>
 
 	<p class="note">
 		<code><?php esc_html_e( 'Subscribe', 'integrate-convertkit-wpforms' ); ?></code>: <?php esc_html_e( 'Subscribes the email address to ConvertKit', 'integrate-convertkit-wpforms' ); ?>
 		<br />
 		<code><?php esc_html_e( 'Form', 'integrate-convertkit-wpforms' ); ?></code>: <?php esc_html_e( 'Susbcribes the email address to ConvertKit, and adds the subscriber to the ConvertKit Form', 'integrate-convertkit-wpforms' ); ?>
+		<br />
+		<code><?php esc_html_e( 'Tag', 'convertkit' ); ?></code>: <?php esc_html_e( 'Susbcribes the email address to ConvertKit, tagging the subscriber', 'integrate-convertkit-wpforms' ); ?>
 	</p>
 </div>

--- a/views/backend/settings-form-marketing-forms-dropdown.php
+++ b/views/backend/settings-form-marketing-forms-dropdown.php
@@ -31,7 +31,7 @@
 			?>
 		</optgroup>
 
-		<optgroup label="<?php esc_attr_e( 'Tags', 'convertkit' ); ?>" id="convertkit-wpforms-tags" data-option-value-prefix="tag:">
+		<optgroup label="<?php esc_attr_e( 'Tags', 'integrate-convertkit-wpforms' ); ?>" id="convertkit-wpforms-tags" data-option-value-prefix="tag:">
 			<?php
 			if ( $tags->exist() ) {
 				foreach ( $tags->get() as $convertkit_tag ) {
@@ -52,6 +52,6 @@
 		<br />
 		<code><?php esc_html_e( 'Form', 'integrate-convertkit-wpforms' ); ?></code>: <?php esc_html_e( 'Susbcribes the email address to ConvertKit, and adds the subscriber to the ConvertKit Form', 'integrate-convertkit-wpforms' ); ?>
 		<br />
-		<code><?php esc_html_e( 'Tag', 'convertkit' ); ?></code>: <?php esc_html_e( 'Susbcribes the email address to ConvertKit, tagging the subscriber', 'integrate-convertkit-wpforms' ); ?>
+		<code><?php esc_html_e( 'Tag', 'integrate-convertkit-wpforms' ); ?></code>: <?php esc_html_e( 'Susbcribes the email address to ConvertKit, tagging the subscriber', 'integrate-convertkit-wpforms' ); ?>
 	</p>
 </div>


### PR DESCRIPTION
## Summary

Adds options to each WPForms Form to tag the subscriber when a form is submitted.

<img width="636" alt="Screenshot 2024-07-31 at 11 21 18" src="https://github.com/user-attachments/assets/8abe320b-69d7-4f5b-9390-7212f22d8186">

## Testing

- `testCreateFormToConvertKitTagMapping`: Test that saving a WPFormsForm to ConvertKit Tag Mapping works.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)