### PR TITLE
Create subscriber with `inactive` state when a Form option is selected

### DIFF
--- a/includes/class-integrate-convertkit-wpforms.php
+++ b/includes/class-integrate-convertkit-wpforms.php
@@ -276,11 +276,15 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 				continue;
 			}
 
+			// Determine resource type, resource ID and subscriber state to use.
+			$resource         = $this->get_resource_type_and_id( $connection['list_id'] );
+			$subscriber_state = $this->get_subscriber_state( $resource['type'] );
+
 			// Subscribe the email address.
 			$subscriber = $api->create_subscriber(
 				$args['email'],
 				( isset( $args['name'] ) ? $args['name'] : '' ),
-				'active',
+				$subscriber_state,
 				( isset( $args['fields'] ) ? $args['fields'] : array() )
 			);
 
@@ -311,26 +315,20 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 			}
 
 			// If the subscribe setting isn't 'subscribe', add the subscriber to the resource type.
-			if ( $connection['list_id'] !== 'subscribe' ) {
-				// Determine the resource type and ID to assign to the subscriber.
-				list( $resource_type, $resource_id ) = explode( ':', $connection['list_id'] );
-
-				// Cast ID.
-				$resource_id = absint( $resource_id );
-
+			if ( $resource['type'] !== 'subscribe' ) {
 				// Add the subscriber to the resource type (form, tag etc).
-				switch ( $resource_type ) {
+				switch ( $resource['type'] ) {
 
 					/**
 					 * Form
 					 */
 					case 'form':
 						// For Legacy Forms, a different endpoint is used.
-						if ( $resource_forms->is_legacy( $resource_id ) ) {
-							$response = $api->add_subscriber_to_legacy_form( $resource_id, $subscriber['subscriber']['id'] );
+						if ( $resource_forms->is_legacy( $resource['id'] ) ) {
+							$response = $api->add_subscriber_to_legacy_form( $resource['id'], $subscriber['subscriber']['id'] );
 						} else {
 							// Add subscriber to form.
-							$response = $api->add_subscriber_to_form( $resource_id, $subscriber['subscriber']['id'] );
+							$response = $api->add_subscriber_to_form( $resource['id'], $subscriber['subscriber']['id'] );
 						}
 						break;
 
@@ -339,7 +337,7 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 					 */
 					case 'sequence':
 						// Add subscriber to sequence.
-						$response = $api->add_subscriber_to_sequence( $resource_id, $subscriber['subscriber']['id'] );
+						$response = $api->add_subscriber_to_sequence( $resource['id'], $subscriber['subscriber']['id'] );
 						break;
 
 					/**
@@ -347,7 +345,7 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 					 */
 					case 'tag':
 						// Add subscriber to tag.
-						$response = $api->tag_subscriber( $resource_id, $subscriber['subscriber']['id'] );
+						$response = $api->tag_subscriber( $resource['id'], $subscriber['subscriber']['id'] );
 						break;
 
 					/**
@@ -359,7 +357,7 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 							sprintf(
 								/* translators: Resource type */
 								esc_html__( 'The resource type %s is unsupported.', 'integrate-convertkit-wpforms' ),
-								$resource_type
+								$resource['type']
 							)
 						);
 						break;
@@ -418,6 +416,46 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 				)
 			);
 		}
+
+	}
+
+	/**
+	 * Returns the subscriber state to use when creating a subscriber.
+	 *
+	 * @since   1.7.3
+	 *
+	 * @param   string $resource_type  Resource Type (subscriber,form,tag,sequence).
+	 * @return  string                  Subscriber state
+	 */
+	private function get_subscriber_state( $resource_type ) {
+
+		return ( $resource_type === 'form' ? 'inactive' : 'active' );
+
+	}
+
+	/**
+	 * Returns an array comprising of the resource type and ID for the given list ID setting.
+	 *
+	 * @since   1.7.3
+	 *
+	 * @param   string $setting    Setting.
+	 * @return  array
+	 */
+	private function get_resource_type_and_id( $setting ) {
+
+		if ( $setting === 'subscribe' ) {
+			return array(
+				'type' => 'subscribe',
+				'id'   => 0,
+			);
+		}
+
+		list( $resource_type, $resource_id ) = explode( ':', $setting );
+
+		return array(
+			'type' => $resource_type,
+			'id'   => absint( $resource_id ),
+		);
 
 	}
 

--- a/includes/class-integrate-convertkit-wpforms.php
+++ b/includes/class-integrate-convertkit-wpforms.php
@@ -278,7 +278,7 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 
 			// Determine resource type, resource ID and subscriber state to use.
 			$resource         = $this->get_resource_type_and_id( $connection['list_id'] );
-			$subscriber_state = $this->get_subscriber_state( $resource['type'] );
+			$subscriber_state = $this->get_initial_subscriber_state( $resource['type'] );
 
 			// Subscribe the email address.
 			$subscriber = $api->create_subscriber(
@@ -427,7 +427,7 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 	 * @param   string $resource_type  Resource Type (subscriber,form,tag,sequence).
 	 * @return  string                  Subscriber state
 	 */
-	private function get_subscriber_state( $resource_type ) {
+	private function get_initial_subscriber_state( $resource_type ) {
 
 		return ( $resource_type === 'form' ? 'inactive' : 'active' );
 

--- a/tests/acceptance/forms/FormBackwardCompatCest.php
+++ b/tests/acceptance/forms/FormBackwardCompatCest.php
@@ -81,6 +81,7 @@ class FormBackwardCompatCest
 		$I->fillField('.ck-tag input[type=text]', $_ENV['CONVERTKIT_API_TAG_ID']);
 
 		// Submit Form.
+		$I->wait(2);
 		$I->click('Submit');
 
 		// Check that no PHP warnings or notices were output.
@@ -157,6 +158,7 @@ class FormBackwardCompatCest
 		$I->fillField('.ck-tag input[type=text]', '1111');
 
 		// Submit Form.
+		$I->wait(2);
 		$I->click('Submit');
 
 		// Check that no PHP warnings or notices were output.
@@ -232,6 +234,7 @@ class FormBackwardCompatCest
 		$I->fillField('.ck-custom-' . $_ENV['CONVERTKIT_API_CUSTOM_FIELD_NAME'] . ' textarea', $customFields[ $_ENV['CONVERTKIT_API_CUSTOM_FIELD_NAME'] ]);
 
 		// Submit Form.
+		$I->wait(2);
 		$I->click('Submit');
 
 		// Check that no PHP warnings or notices were output.
@@ -307,6 +310,7 @@ class FormBackwardCompatCest
 		$I->fillField('.ck-custom-fakeCustomFieldName textarea', $customFields['fakeCustomFieldName']);
 
 		// Submit Form.
+		$I->wait(2);
 		$I->click('Submit');
 
 		// Check that no PHP warnings or notices were output.

--- a/tests/acceptance/forms/FormCest.php
+++ b/tests/acceptance/forms/FormCest.php
@@ -584,6 +584,7 @@ class FormCest
 		}
 
 		// Submit Form.
+		$I->wait(2);
 		$I->click('Submit');
 
 		// Check that no PHP warnings or notices were output.

--- a/tests/acceptance/recommendations/RecommendationsCest.php
+++ b/tests/acceptance/recommendations/RecommendationsCest.php
@@ -199,6 +199,7 @@ class RecommendationsCest
 		$I->fillField('.wpforms-field-email input[type=email]', $emailAddress);
 
 		// Submit Form.
+		$I->wait(2);
 		$I->click('Submit');
 
 		// Wait for Creator Network Recommendations modal to display.


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://linear.app/kit/issue/PLAT-2027/platform-v4-api-issue-post-to-create-a-subscriber-doesnt-appear-to), by calling `create_subscriber` with `state` = `inactive` when a Form is selected as the resource to assign to the subscriber in Contact Form 7, Forminator and WishList Member.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)