### PR TITLE
Add Reconnect link

### DIFF
--- a/includes/class-integrate-convertkit-wpforms.php
+++ b/includes/class-integrate-convertkit-wpforms.php
@@ -72,6 +72,51 @@ class Integrate_ConvertKit_WPForms extends WPForms_Provider {
 	}
 
 	/**
+	 * Add provider to the Settings Integrations tab.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $active   Array of active connections.
+	 * @param array $settings Array of all connections settings.
+	 */
+	public function integrations_tab_options( $active, $settings ) {
+
+		// If no Kit accounts connected to WPForms, don't modify the UI.
+		if ( ! array_key_exists( $this->slug, $settings ) ) {
+			parent::integrations_tab_options( $active, $settings );
+			return;
+		}
+		if ( ! count( $settings[ $this->slug ] ) ) {
+			parent::integrations_tab_options( $active, $settings );
+			return;
+		}
+
+		// Initialize API to generate OAuth URL.
+		$api = new Integrate_ConvertKit_WPForms_API(
+			INTEGRATE_CONVERTKIT_WPFORMS_OAUTH_CLIENT_ID,
+			INTEGRATE_CONVERTKIT_WPFORMS_OAUTH_REDIRECT_URI
+		);
+
+		// Fetch UI.
+		ob_start();
+		parent::integrations_tab_options( $active, $settings );
+		$html = ob_get_clean();
+
+		// Inject Reconnect button for each Kit account.
+		$reconnect_button = sprintf(
+			'<a href="%s" class="%s-reconnect">%s</a>',
+			esc_url( $api->get_oauth_url( admin_url( 'admin.php?page=wpforms-settings&view=integrations' ) ) ),
+			esc_attr( $this->slug ),
+			esc_html__( 'Reconnect', 'integrate-convertkit-wpforms' )
+		);
+		$html             = str_replace( '</a></span></li>', '</a></span>' . $reconnect_button . '</li>', $html );
+
+		// Output UI.
+		echo $html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+	}
+
+	/**
 	 * Runs update/upgrade routines between Plugin versions.
 	 *
 	 * @since   1.5.0

--- a/tests/acceptance/general/IntegrationsCest.php
+++ b/tests/acceptance/general/IntegrationsCest.php
@@ -20,8 +20,8 @@ class IntegrationsCest
 	}
 
 	/**
-	 * Test that adding a ConvertKit account to the ConvertKit integration sections
-	 * works with valid API credentials.
+	 * Test that adding a Kit account to the Kit integration sections
+	 * works when connecting, reconnecting and disconnecting.
 	 *
 	 * @since   1.5.0
 	 *
@@ -71,6 +71,21 @@ class IntegrationsCest
 		// Confirm that the Access Token and Refresh Token were saved to the database.
 		// This sanity checks that we didn't accidentally save the API Key to the API Secret field as we did in 1.5.7 and lower.
 		$I->assertTrue($I->checkWPFormsIntegrationExists($I, $_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'], $_ENV['CONVERTKIT_OAUTH_REFRESH_TOKEN']));
+
+		// Confirm that the connection can be reconnected.
+		$I->seeElementInDOM('a.convertkit-reconnect');
+		$reconnectURL = $I->grabAttributeFrom('a.convertkit-reconnect', 'href');
+		$I->assertStringContainsString(
+			'https://app.kit.com/oauth/authorize?client_id=' . $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'] . '&response_type=code&redirect_uri=' . urlencode( $_ENV['KIT_OAUTH_REDIRECT_URI'] ),
+			$reconnectURL
+		);
+		$I->assertStringContainsString(
+			'&state=' . $I->apiEncodeState(
+				$_ENV['TEST_SITE_WP_URL'] . '/wp-admin/admin.php?page=wpforms-settings&view=integrations',
+				$_ENV['CONVERTKIT_OAUTH_CLIENT_ID']
+			),
+			$reconnectURL
+		);
 
 		// Confirm that the connection can be disconnected.
 		$I->click('Disconnect');


### PR DESCRIPTION
## Summary

Adds a Reconnect link to existing Kit OAuth connections at WPForms > Settings > Integrations
![Screenshot 2024-11-11 at 12 25 00](https://github.com/user-attachments/assets/0a8e0abc-87b7-426a-a364-8c77cde85e7d)

Now that each Kit connection is stored [using its account ID](https://github.com/ConvertKit/convertkit-wpforms/pull/69), and [different tokens are issued to different sites using the same Kit account](https://github.com/ConvertKit/convertkit-wpforms/pull/70), it's unlikely this will be needed - but useful for creators should they wish to go through OAuth again to reconnect.

## Testing

- `testAddIntegrationWithValidCredentials`: Test that the Reconnect option is displayed on an existing connection, with the correct URL to begin the OAuth authorization process.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)