### PR TITLE
Revoke and Remove Tokens on Uninstall

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,15 +52,11 @@ jobs:
       fail-fast: false
       matrix:
         wp-versions: [ 'latest' ] #[ '6.1.1', 'latest' ]
-        php-versions: [ '8.1', '8.2', '8.3', '8.4' ] #[ '7.3', '7.4', '8.0', '8.1' ]
+        php-versions: [ '8.1' ] #[ '7.3', '7.4', '8.0', '8.1' ]
         
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [
-          'EndToEnd/forms',
-          'EndToEnd/general',
-          'EndToEnd/recommendations',
-          'EndToEnd/uninstall',
-          'Integration'
+          'EndToEnd/uninstall'
         ]
 
     # Steps to install, configure and run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,11 +52,15 @@ jobs:
       fail-fast: false
       matrix:
         wp-versions: [ 'latest' ] #[ '6.1.1', 'latest' ]
-        php-versions: [ '8.1' ] #[ '7.3', '7.4', '8.0', '8.1' ]
+        php-versions: [ '8.1', '8.2', '8.3', '8.4' ] #[ '7.3', '7.4', '8.0', '8.1' ]
         
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [
-          'EndToEnd/uninstall'
+          'EndToEnd/forms',
+          'EndToEnd/general',
+          'EndToEnd/recommendations',
+          'EndToEnd/uninstall',
+          'Integration'
         ]
 
     # Steps to install, configure and run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,6 +59,7 @@ jobs:
           'EndToEnd/forms',
           'EndToEnd/general',
           'EndToEnd/recommendations',
+          'EndToEnd/uninstall',
           'Integration'
         ]
 

--- a/tests/EndToEnd/uninstall/UninstallCest.php
+++ b/tests/EndToEnd/uninstall/UninstallCest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests\EndToEnd;
+
+use Tests\Support\EndToEndTester;
+
+/**
+ * Tests Plugin uninstallation.
+ *
+ * @since   1.9.2
+ */
+class UninstallCest
+{
+	/**
+	 * Test that the Plugin's access and refresh tokens are revoked, and all v4 and v3
+	 * API credentials are removed from the Plugin's settings when the Plugin is deleted.
+	 *
+	 * @since   1.9.2
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testPluginDeletionRevokesAndRemovesTokens(EndToEndTester $I)
+	{
+		// Activate this Plugin.
+		$I->activateConvertKitPlugin($I);
+
+		// Generate an access token and refresh token by API key and secret.
+		// We don't use the tokens from the environment, as revoking those
+		// would result in later tests failing.
+		$result = wp_remote_post(
+			'https://api.kit.com/wordpress/accounts/oauth_access_token',
+			[
+				'headers' => [
+					'Content-Type' => 'application/json',
+				],
+				'body'    => wp_json_encode(
+					[
+						'api_key'     => $_ENV['CONVERTKIT_API_KEY'],
+						'api_secret'  => $_ENV['CONVERTKIT_API_SECRET'],
+						'client_id'   => $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
+						'tenant_name' => wp_generate_password( 10, false ), // Random tenant name to produce a token for this request only.
+					]
+				),
+			]
+		);
+		$tokens = json_decode(wp_remote_retrieve_body($result), true)['oauth'];
+
+		// Store the tokens and API keys in the Plugin's settings.
+		$I->setupConvertKitPlugin(
+			$I,
+			accessToken: $tokens['access_token'],
+			refreshToken: $tokens['refresh_token'],
+			apiKey: $_ENV['CONVERTKIT_API_KEY'],
+			apiSecret: $_ENV['CONVERTKIT_API_SECRET']
+		);
+
+		// Deactivate the Plugin.
+		$I->deactivateConvertKitPlugin($I);
+
+		// Delete the Plugin.
+		$I->deleteKitPlugin($I);
+
+		// Confirm the credentials have been removed from the Plugin's settings.
+		$I->wait(3);
+		$settings = $I->grabOptionFromDatabase('woocommerce_ckwc_settings');
+		$I->assertEmpty($settings['access_token']);
+		$I->assertEmpty($settings['refresh_token']);
+		$I->assertEmpty($settings['api_key']);
+		$I->assertEmpty($settings['api_secret']);
+
+		// Confirm attempting to use the revoked access token no longer works.
+		$result = wp_remote_get(
+			'https://api.kit.com/v4/account',
+			[
+				'headers' => [
+					'Authorization' => 'Bearer ' . $tokens['access_token'],
+				],
+			]
+		);
+		$data   = json_decode(wp_remote_retrieve_body($result), true);
+		$I->assertArrayHasKey( 'errors', $data );
+		$I->assertEquals( 'The access token was revoked', $data['errors'][0] );
+
+		// Confirm attempting to use the revoked refresh token no longer works.
+		$result = wp_remote_post(
+			'https://api.kit.com/v4/oauth/token',
+			[
+				'headers' => [
+					'Authorization' => 'Bearer ' . $tokens['access_token'],
+				],
+				'body'    => [
+					'client_id'     => $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'],
+					'grant_type'    => 'refresh_token',
+					'refresh_token' => $tokens['refresh_token'],
+				],
+			]
+		);
+		$data   = json_decode(wp_remote_retrieve_body($result), true);
+		$I->assertArrayHasKey( 'error', $data );
+		$I->assertEquals( 'invalid_grant', $data['error'] );
+	}
+}

--- a/tests/EndToEnd/uninstall/UninstallCest.php
+++ b/tests/EndToEnd/uninstall/UninstallCest.php
@@ -46,7 +46,7 @@ class UninstallCest
 		$tokens = json_decode(wp_remote_retrieve_body($result), true)['oauth'];
 
 		// Store the tokens and API keys in the Plugin's settings.
-		$I->setupConvertKitPlugin(
+		$I->setupWPFormsIntegration(
 			$I,
 			accessToken: $tokens['access_token'],
 			refreshToken: $tokens['refresh_token'],
@@ -62,11 +62,12 @@ class UninstallCest
 
 		// Confirm the credentials have been removed from the Plugin's settings.
 		$I->wait(3);
-		$settings = $I->grabOptionFromDatabase('woocommerce_ckwc_settings');
-		$I->assertEmpty($settings['access_token']);
-		$I->assertEmpty($settings['refresh_token']);
-		$I->assertEmpty($settings['api_key']);
-		$I->assertEmpty($settings['api_secret']);
+		$settings   = $I->grabOptionFromDatabase('wpforms_providers');
+		$connection = reset($settings['convertkit']);
+		$I->assertEmpty($connection['access_token']);
+		$I->assertEmpty($connection['refresh_token']);
+		$I->assertEmpty($connection['api_key']);
+		$I->assertEmpty($connection['api_secret']);
 
 		// Confirm attempting to use the revoked access token no longer works.
 		$result = wp_remote_get(

--- a/tests/Support/Helper/Plugin.php
+++ b/tests/Support/Helper/Plugin.php
@@ -36,8 +36,7 @@ class Plugin extends \Codeception\Module
 	}
 
 	/**
-	 * Helper method to delete the Kit Plugin, checking
-	 * it deleted and no errors were output.
+	 * Helper method to delete the Kit Plugin.
 	 *
 	 * @since   1.9.2
 	 *

--- a/tests/Support/Helper/Plugin.php
+++ b/tests/Support/Helper/Plugin.php
@@ -36,6 +36,19 @@ class Plugin extends \Codeception\Module
 	}
 
 	/**
+	 * Helper method to delete the Kit Plugin, checking
+	 * it deleted and no errors were output.
+	 *
+	 * @since   1.9.2
+	 *
+	 * @param   EndToEndTester $I     EndToEndTester.
+	 */
+	public function deleteKitPlugin($I)
+	{
+		$I->deleteThirdPartyPlugin($I, 'integrate-convertkit-wpforms');
+	}
+
+	/**
 	 * Helper method to determine that the order of the Form resources in the given
 	 * select element are in the expected alphabetical order.
 	 *

--- a/tests/Support/Helper/ThirdPartyPlugin.php
+++ b/tests/Support/Helper/ThirdPartyPlugin.php
@@ -75,6 +75,39 @@ class ThirdPartyPlugin extends \Codeception\Module
 	}
 
 	/**
+	 * Helper method to delete a third party Plugin, checking
+	 * it deleted and no errors were output.
+	 *
+	 * @since   1.9.2
+	 *
+	 * @param   EndToEndTester $I      EndToEnd Tester.
+	 * @param   string         $name   Plugin Slug.
+	 */
+	public function deleteThirdPartyPlugin($I, $name)
+	{
+		// Login as the Administrator, if we're not already logged in.
+		if ( ! $this->amLoggedInAsAdmin($I) ) {
+			$this->doLoginAsAdmin($I);
+		}
+
+		// Go to the Plugins screen in the WordPress Administration interface.
+		$I->amOnPluginsPage();
+
+		// Wait for the Plugins page to load.
+		$I->waitForElementVisible('body.plugins-php');
+
+		// Delete the Plugin.
+		$I->waitForElementVisible('a#delete-' . $name);
+		$I->click('a#delete-' . $name);
+
+		// Click the confirmation dialog.
+		$I->acceptPopup();
+
+		// Wait for the Plugin to be marked as deleted.
+		$I->waitForElementNotVisible('table.plugins tr.deleted[data-slug=' . $name . ']');
+	}
+
+	/**
 	 * Helper method to check if the Administrator is logged in.
 	 *
 	 * @since   1.8.1

--- a/uninstall.php
+++ b/uninstall.php
@@ -30,53 +30,53 @@ if ( ! array_key_exists( 'convertkit', $providers ) ) {
 }
 
 // Iterate through each connection, revoking the tokens.
-foreach ( $providers['convertkit'] as $account_id =>$connection ) {
-    // Revoke Access Token.
-    if ( array_key_exists( 'access_token', $connection ) && ! empty( $connection['access_token'] ) ) {
-        wp_remote_post(
-            'https://api.kit.com/v4/oauth/revoke',
-            array(
-                'headers' => array(
-                    'Accept'       => 'application/json',
-                    'Content-Type' => 'application/json',
-                ),
-                'body'    => wp_json_encode(
-                    array(
-                        'client_id' => 'L0kyADsB3WP5zO5MvUpXQU64gIntQg9BBAIme17r_7A',
-                        'token'     => $connection['access_token'],
-                    )
-                ),
-                'timeout' => 5,
-            )
-        );
-    }
+foreach ( $providers['convertkit'] as $account_id => $connection ) {
+	// Revoke Access Token.
+	if ( array_key_exists( 'access_token', $connection ) && ! empty( $connection['access_token'] ) ) {
+		wp_remote_post(
+			'https://api.kit.com/v4/oauth/revoke',
+			array(
+				'headers' => array(
+					'Accept'       => 'application/json',
+					'Content-Type' => 'application/json',
+				),
+				'body'    => wp_json_encode(
+					array(
+						'client_id' => 'L0kyADsB3WP5zO5MvUpXQU64gIntQg9BBAIme17r_7A',
+						'token'     => $connection['access_token'],
+					)
+				),
+				'timeout' => 5,
+			)
+		);
+	}
 
-    // Revoke Refresh Token.
-    if ( array_key_exists( 'refresh_token', $connection ) && ! empty( $connection['refresh_token'] ) ) {
-        wp_remote_post(
-            'https://api.kit.com/v4/oauth/revoke',
-            array(
-                'headers' => array(
-                    'Accept'       => 'application/json',
-                    'Content-Type' => 'application/json',
-                ),
-                'body'    => wp_json_encode(
-                    array(
-                        'client_id' => 'L0kyADsB3WP5zO5MvUpXQU64gIntQg9BBAIme17r_7A',
-                        'token'     => $connection['refresh_token'],
-                    )
-                ),
-                'timeout' => 5,
-            )
-        );
-    }
+	// Revoke Refresh Token.
+	if ( array_key_exists( 'refresh_token', $connection ) && ! empty( $connection['refresh_token'] ) ) {
+		wp_remote_post(
+			'https://api.kit.com/v4/oauth/revoke',
+			array(
+				'headers' => array(
+					'Accept'       => 'application/json',
+					'Content-Type' => 'application/json',
+				),
+				'body'    => wp_json_encode(
+					array(
+						'client_id' => 'L0kyADsB3WP5zO5MvUpXQU64gIntQg9BBAIme17r_7A',
+						'token'     => $connection['refresh_token'],
+					)
+				),
+				'timeout' => 5,
+			)
+		);
+	}
 
-    // Remove credentials from settings.
-    $providers['convertkit'][ $account_id ]['access_token']  = '';
-    $providers['convertkit'][ $account_id ]['refresh_token'] = '';
-    $providers['convertkit'][ $account_id ]['token_expires'] = '';
-    $providers['convertkit'][ $account_id ]['api_key']       = '';
-    $providers['convertkit'][ $account_id ]['api_secret']    = '';
+	// Remove credentials from settings.
+	$providers['convertkit'][ $account_id ]['access_token']  = '';
+	$providers['convertkit'][ $account_id ]['refresh_token'] = '';
+	$providers['convertkit'][ $account_id ]['token_expires'] = '';
+	$providers['convertkit'][ $account_id ]['api_key']       = '';
+	$providers['convertkit'][ $account_id ]['api_secret']    = '';
 }
 
 // Save settings.

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Uninstall routine. Runs when the Plugin is deleted
+ * at Plugins > Delete.
+ *
+ * @package CKWC
+ * @author ConvertKit
+ */
+
+// If uninstall.php is not called by WordPress, die.
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+	die;
+}
+
+// Only WordPress and PHP methods can be used. Plugin classes and methods
+// are not reliably available due to the Plugin being deactivated and going
+// through deletion now.
+
+// Get providers.
+$providers = get_option( 'wpforms_providers' );
+
+// Bail if no providers exist.
+if ( ! $providers ) {
+	return;
+}
+
+// Bail if no Kit connections exist.
+if ( ! array_key_exists( 'convertkit', $providers ) ) {
+	return;
+}
+
+// Iterate through each connection, revoking the tokens.
+foreach ( $providers['convertkit'] as $account_id =>$connection ) {
+    // Revoke Access Token.
+    if ( array_key_exists( 'access_token', $connection ) && ! empty( $connection['access_token'] ) ) {
+        wp_remote_post(
+            'https://api.kit.com/v4/oauth/revoke',
+            array(
+                'headers' => array(
+                    'Accept'       => 'application/json',
+                    'Content-Type' => 'application/json',
+                ),
+                'body'    => wp_json_encode(
+                    array(
+                        'client_id' => 'L0kyADsB3WP5zO5MvUpXQU64gIntQg9BBAIme17r_7A',
+                        'token'     => $connection['access_token'],
+                    )
+                ),
+                'timeout' => 5,
+            )
+        );
+    }
+
+    // Revoke Refresh Token.
+    if ( array_key_exists( 'refresh_token', $connection ) && ! empty( $connection['refresh_token'] ) ) {
+        wp_remote_post(
+            'https://api.kit.com/v4/oauth/revoke',
+            array(
+                'headers' => array(
+                    'Accept'       => 'application/json',
+                    'Content-Type' => 'application/json',
+                ),
+                'body'    => wp_json_encode(
+                    array(
+                        'client_id' => 'L0kyADsB3WP5zO5MvUpXQU64gIntQg9BBAIme17r_7A',
+                        'token'     => $connection['refresh_token'],
+                    )
+                ),
+                'timeout' => 5,
+            )
+        );
+    }
+
+    // Remove credentials from settings.
+    $providers['convertkit'][ $account_id ]['access_token']  = '';
+    $providers['convertkit'][ $account_id ]['refresh_token'] = '';
+    $providers['convertkit'][ $account_id ]['token_expires'] = '';
+    $providers['convertkit'][ $account_id ]['api_key']       = '';
+    $providers['convertkit'][ $account_id ]['api_secret']    = '';
+}
+
+// Save settings.
+update_option( 'wpforms_providers', $providers );


### PR DESCRIPTION
## Summary

When the user uninstalls the Kit for WPForms Plugin from their WordPress Site:
- Revokes all access and refresh tokens by calling the `oauth/revoke` endpoint
- Removes all v3 API Key, v3 Secret, v4 Access Token, v4 Refresh Token and v4 Token Expires settings from the database.

https://developer.wordpress.org/plugins/plugin-basics/uninstall-methods/ defines "Uninstall" as:

> A plugin is considered uninstalled if a user has deactivated the plugin, and then clicks the delete link within the WordPress Admin.

## Testing

- `testPluginDeletionRevokesAndRemovesTokens `: test that uninstalling (deleting) the Plugin revokes and removes tokens.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)