### PR TITLE
Remove v3 API Key and Secret on Plugin Update

### DIFF
--- a/includes/class-integrate-convertkit-wpforms-setup.php
+++ b/includes/class-integrate-convertkit-wpforms-setup.php
@@ -52,8 +52,53 @@ class Integrate_ConvertKit_WPForms_Setup {
 			$this->migrate_form_settings();
 		}
 
+		// Actions that should run regardless of the version number
+		// whenever the Plugin is updated.
+		$this->remove_v3_api_key_and_secret_from_settings();
+
 		// Update the installed version number in the options table.
 		update_option( 'integrate_convertkit_wpforms_version', INTEGRATE_CONVERTKIT_WPFORMS_VERSION );
+
+	}
+
+	/**
+	 * Remove v3 API key and Secret from settings.
+	 *
+	 * @since   1.9.2
+	 */
+	private function remove_v3_api_key_and_secret_from_settings() {
+
+		// Bail if the wpforms_get_providers_options() function isn't available.
+		if ( ! function_exists( 'wpforms_get_providers_options' ) ) {
+			return;
+		}
+
+		// Get providers.
+		$providers = wpforms_get_providers_options();
+
+		// Bail if no providers exist.
+		if ( ! $providers ) {
+			return;
+		}
+
+		// Bail if no Kit connections exist.
+		if ( ! array_key_exists( 'convertkit', $providers ) ) {
+			return;
+		}
+
+		// Iterate through providers.
+		foreach ( $providers['convertkit'] as $account_id => $settings ) {
+			// Remove v3 API Secret from settings.
+			$settings['api_key']    = '';
+			$settings['api_secret'] = '';
+
+			// Save settings.
+			wpforms_update_providers_options(
+				'convertkit',
+				$settings,
+				$account_id
+			);
+		}
 
 	}
 

--- a/tests/EndToEnd/general/UpgradePathsCest.php
+++ b/tests/EndToEnd/general/UpgradePathsCest.php
@@ -39,11 +39,8 @@ class UpgradePathsCest
 
 		// Get first integration for ConvertKit, and confirm it has the expected array structure and values.
 		$account = reset( $providers['convertkit'] );
-		$I->assertArrayHasKey('api_key', $account);
-		$I->assertArrayHasKey('api_secret', $account);
 		$I->assertArrayHasKey('label', $account);
 		$I->assertArrayHasKey('date', $account);
-		$I->assertEquals($_ENV['CONVERTKIT_API_KEY'], $account['api_key']);
 		$I->assertEquals('Kit', $account['label']);
 	}
 
@@ -148,5 +145,46 @@ class UpgradePathsCest
 				'post_content' => json_encode( $settings ), // phpcs:ignore WordPress.WP.AlternativeFunctions
 			]
 		);
+	}
+
+	/**
+	 * Tests that the v3 API Key and Secret are removed from settings when upgrading to 1.9.2 or later.
+	 *
+	 * @since   1.9.2
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testV3APIKeyAndSecretRemovedFromSettings(EndToEndTester $I)
+	{
+		// Setup Plugin's settings with an API Key and Secret.
+		$I->setupWPFormsIntegrationWithAPIKeyAndSecret($I);
+
+		// Define an installation version older than 1.9.2.
+		$I->haveOptionInDatabase('integrate_convertkit_wpforms_version', '1.9.0');
+
+		// Activate Plugins.
+		$I->activateThirdPartyPlugin($I, 'wpforms-lite');
+		$I->activateConvertKitPlugin($I);
+
+		// Confirm the provider connections no longer have a value for the v3 API Key and Secret.
+		$settings   = $I->grabOptionFromDatabase('wpforms_providers');
+		$connection = reset($settings['convertkit']);
+		$I->assertEmpty($connection['api_key']);
+		$I->assertEmpty($connection['api_secret']);
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   1.9.2
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function _passed(EndToEndTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->deactivateThirdPartyPlugin($I, 'wpforms-lite');
 	}
 }


### PR DESCRIPTION
## Summary

Whenever a new Plugin release is published and the creator updates to the latest version, checks if a v3 API Key and/or Secret exists, and if so deletes it from the Plugin's settings.

v3 API Keys and Secrets were retained following the introduction of the v4 API, to [permit automatic exchange](https://github.com/Kit/convertkit-wpforms/pull/49) of v3 API Keys for v4 tokens. This was in July 2024, so by now the v3 API Key and Secret isn't needed.

## Testing

- `testV3APIKeyAndSecretRemovedFromSettings`: Test that a v3 API Key and Secret are removed from the Plugin's settings when specified.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)