### PR TITLE
Tests: Fix `testCreateFormWithInvalidCustomField`

### DIFF
--- a/tests/EndToEnd/forms/FormBackwardCompatCest.php
+++ b/tests/EndToEnd/forms/FormBackwardCompatCest.php
@@ -323,8 +323,8 @@ class FormBackwardCompatCest
 		$I->waitForElementVisible('.wpforms-confirmation-scroll');
 		$I->seeInSource('Thanks for contacting us! We will be in touch with you shortly.');
 
-		// Check API to confirm subscriber was sent.
-		$I->apiCheckSubscriberExists($I, $emailAddress, $firstName);
+		// Check subscriber does not exist, as specifying an invalid custom field will result in an API error.
+		$I->apiCheckSubscriberDoesNotExist($I, $emailAddress);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Updates the `testCreateFormWithInvalidCustomField`, as creating a subscriber with an invalid custom field will now return an error [due to this PR](https://github.com/Kit/convertkit/pull/42934).

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)