### PR TITLE
Add Security Disclosure Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+This security policy applies to public projects under the [Kit organization](https://github.com/kit) on GitHub.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report via any of the below:
+
+- [BugCrowd](https://docs.bugcrowd.com/researchers/reporting-managing-submissions/reporting-a-bug/#creating-a-vulnerability-report)
+- [PatchStack]()
+- [GitHub](https://github.com/Kit/convertkit-wpforms/security/advisories)
+- [Email](mailto:security@kit.com)
+
+Please do **not** report security issues publicly via GitHub issues or discussions. Security reports sent via the above channels be acknowledged within 48 hours.
+
+## Security Disclosure Process
+
+When reporting a security vulnerability, please include:
+
+1. **Description** - A clear description of the vulnerability
+2. **Impact** - What kind of vulnerability it is and who it impacts
+3. **Reproduction** - Detailed steps to reproduce the issue
+4. **Proof of Concept** - If applicable, include proof-of-concept code
+5. **Suggested Fix** - If you have ideas for how to fix the issue
+
+## Security Response Timeline
+
+- **Initial Response**: Within 48 hours of receiving the report
+- **Investigation**: We will investigate and validate the reported vulnerability
+- **Fix Development**: Development of a patch or mitigation strategy
+- **Release**: Coordinated disclosure and release of security update
+- **Public Disclosure**: After users have had time to upgrade

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ This security policy applies to public projects under the [Kit organization](htt
 
 If you discover a security vulnerability, please report via any of the below:
 
-- [BugCrowd](https://docs.bugcrowd.com/researchers/reporting-managing-submissions/reporting-a-bug/#creating-a-vulnerability-report)
-- [PatchStack]()
+- [Kit](https://kit.com/report-vulnerability)
+- [PatchStack](https://patchstack.com/database/vdp/48836c47-fab2-44e1-a46d-05f3fcae6c13)
 - [GitHub](https://github.com/Kit/convertkit-wpforms/security/advisories)
 - [Email](mailto:security@kit.com)
 

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,9 @@ Full plugin documentation is located [here](https://cultivatewp.com/our-plugins/
 
 No. You must first have an account on kit.com, but you do not have to use a paid plan!
 
+= Where do I report security bugs found in this plugin? =
+Please report security bugs found in the source code of the plugin through the [Patchstack Vulnerability Disclosure Program](https://patchstack.com/database/vdp/48836c47-fab2-44e1-a46d-05f3fcae6c13). The Patchstack team will assist you with verification, CVE assignment, and notify the developers of this plugin.
+
 == Screenshots ==
 
 1. WPForms Kit API Connections at WPForms > Settings > Integrations > Kit


### PR DESCRIPTION
## Summary

Adds a security disclosure policy, including the required update to the Plugin's readme.txt file for PatchStack to permit us to [view security vulnerability disclosures](https://wpzinc.slack.com/archives/C02KFR6N1GF/p1783383622365749) for this Plugin.

<img width="547" height="723" alt="Screenshot 2026-07-08 at 15 51 39" src="https://github.com/user-attachments/assets/439be44c-5b66-4fe6-85ea-87ac1dc7a88b" />

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)