### PR TITLE
Tests: Disable WPForms Setup Wizard

### DIFF
--- a/tests/Support/Data/dump.sql
+++ b/tests/Support/Data/dump.sql
@@ -204,10 +204,7 @@ INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`
 (123, 'theme_mods_twentytwentythree', 'a:1:{s:18:\"custom_css_post_id\";i:-1;}',  'yes'),
 (124, 'db_upgraded',  '', 'yes'),
 (125, 'can_compress_scripts', '1',  'yes'),
-(126, 'WishListMemberOptions_Migrated', '1',  'yes'),
-(127, 'widget_wishlistwidget',  'a:1:{s:12:\"_multiwidget\";i:1;}', 'yes'),
-(128, 'WishListMemberOptions_MigrateLevelData', '1',  'yes'),
-(129, 'WishListMemberOptions_MigrateContentLevelData',  '1',  'yes');
+(126, 'wpforms_setup_wizard_completed', '1',  'yes');
 
 DROP TABLE IF EXISTS `wp_postmeta`;
 CREATE TABLE `wp_postmeta` (


### PR DESCRIPTION
## Summary

Disables WPForm's Setup Wizard in tests by setting the `wpforms_setup_wizard_completed` option. Otherwise, WPForms attempts to load `https://wpformsapi.com/setupwizard/v1` on activation, which doesn't work in end to end / headless tests:

<img width="1920" height="937" alt="Tests EndToEnd ActivateDeactivatePluginCest testPluginActivationDeactivation headless fail" src="https://github.com/user-attachments/assets/3b21fef1-ee50-4965-82d9-0637dbf9b1b4" />

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)