### PR TITLE
Run Tests against WordPress 7.1 RC3

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -70,7 +70,7 @@ jobs:
     # Defines the WordPress and PHP Versions matrix to run tests on.
     strategy:
       matrix:
-        wp-versions: [ 'latest' ] #[ '6.1.1', 'latest' ]
+        wp-versions: [ '7.1-beta2' ] #[ '6.1.1', 'latest' ]
         php-versions: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ] #[ '7.3', '7.4', '8.0', '8.1' ]
 
     # Steps to install, configure and run tests

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -70,7 +70,7 @@ jobs:
     # Defines the WordPress and PHP Versions matrix to run tests on.
     strategy:
       matrix:
-        wp-versions: [ '7.1-beta4' ] #[ '6.1.1', 'latest' ]
+        wp-versions: [ '7.1-RC1' ] #[ '6.1.1', 'latest' ]
         php-versions: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ] #[ '7.3', '7.4', '8.0', '8.1' ]
 
     # Steps to install, configure and run tests

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -70,7 +70,7 @@ jobs:
     # Defines the WordPress and PHP Versions matrix to run tests on.
     strategy:
       matrix:
-        wp-versions: [ '7.1-beta2' ] #[ '6.1.1', 'latest' ]
+        wp-versions: [ '7.1-beta3' ] #[ '6.1.1', 'latest' ]
         php-versions: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ] #[ '7.3', '7.4', '8.0', '8.1' ]
 
     # Steps to install, configure and run tests

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -70,7 +70,7 @@ jobs:
     # Defines the WordPress and PHP Versions matrix to run tests on.
     strategy:
       matrix:
-        wp-versions: [ '7.1-RC1' ] #[ '6.1.1', 'latest' ]
+        wp-versions: [ '7.1-RC3' ] #[ '6.1.1', 'latest' ]
         php-versions: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ] #[ '7.3', '7.4', '8.0', '8.1' ]
 
     # Steps to install, configure and run tests

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -70,7 +70,7 @@ jobs:
     # Defines the WordPress and PHP Versions matrix to run tests on.
     strategy:
       matrix:
-        wp-versions: [ '7.1-beta3' ] #[ '6.1.1', 'latest' ]
+        wp-versions: [ '7.1-beta4' ] #[ '6.1.1', 'latest' ]
         php-versions: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ] #[ '7.3', '7.4', '8.0', '8.1' ]
 
     # Steps to install, configure and run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        wp-versions: [ 'latest' ] #[ '6.1.1', 'latest' ]
+        wp-versions: [ '7.1-beta2' ] #[ '6.1.1', 'latest' ]
         php-versions: [ '8.1', '8.2', '8.3', '8.4' ] #[ '7.3', '7.4', '8.0', '8.1' ]
         
         # Folder names within the 'tests' folder to run tests in parallel.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        wp-versions: [ '7.1-beta2' ] #[ '6.1.1', 'latest' ]
+        wp-versions: [ '7.1-beta3' ] #[ '6.1.1', 'latest' ]
         php-versions: [ '8.1', '8.2', '8.3', '8.4' ] #[ '7.3', '7.4', '8.0', '8.1' ]
         
         # Folder names within the 'tests' folder to run tests in parallel.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        wp-versions: [ '7.1-beta3' ] #[ '6.1.1', 'latest' ]
+        wp-versions: [ '7.1-beta4' ] #[ '6.1.1', 'latest' ]
         php-versions: [ '8.1', '8.2', '8.3', '8.4' ] #[ '7.3', '7.4', '8.0', '8.1' ]
         
         # Folder names within the 'tests' folder to run tests in parallel.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        wp-versions: [ '7.1-RC1' ] #[ '6.1.1', 'latest' ]
+        wp-versions: [ '7.1-RC3' ] #[ '6.1.1', 'latest' ]
         php-versions: [ '8.1', '8.2', '8.3', '8.4' ] #[ '7.3', '7.4', '8.0', '8.1' ]
         
         # Folder names within the 'tests' folder to run tests in parallel.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        wp-versions: [ '7.1-beta4' ] #[ '6.1.1', 'latest' ]
+        wp-versions: [ '7.1-RC1' ] #[ '6.1.1', 'latest' ]
         php-versions: [ '8.1', '8.2', '8.3', '8.4' ] #[ '7.3', '7.4', '8.0', '8.1' ]
         
         # Folder names within the 'tests' folder to run tests in parallel.

--- a/tests/Support/Helper/ThirdPartyPlugin.php
+++ b/tests/Support/Helper/ThirdPartyPlugin.php
@@ -32,7 +32,7 @@ class ThirdPartyPlugin extends \Codeception\Module
 		$I->waitForElementVisible('body.plugins-php');
 
 		// Activate the Plugin.
-		$I->checkOption('//*[@data-slug="' . $name . '"]/th/input');
+		$I->checkOption('//*[@data-slug="' . $name . '"]//input[@type="checkbox"]');
 		$I->selectOption('action', 'activate-selected');
 		$I->click('#doaction');
 
@@ -66,7 +66,7 @@ class ThirdPartyPlugin extends \Codeception\Module
 		$I->waitForElementVisible('body.plugins-php');
 
 		// Deactivate the Plugin.
-		$I->checkOption('//*[@data-slug="' . $name . '"]/th/input');
+		$I->checkOption('//*[@data-slug="' . $name . '"]//input[@type="checkbox"]');
 		$I->selectOption('action', 'deactivate-selected');
 		$I->click('#doaction');
 


### PR DESCRIPTION
## Summary

Run Tests against WordPress 7.1 RC3, the final RC before 7.1 releases August 19th:
https://make.wordpress.org/core/7-1/

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)